### PR TITLE
chore: add .mcp.json for local development

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "cratesio-mcp": {
+      "command": "cargo",
+      "args": ["run", "--", "--transport", "stdio"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `.mcp.json` so Claude Code auto-discovers the server when working in this repo
- Runs via `cargo run` over stdio for local testing

## Test plan

- [ ] Start a new Claude Code session in the repo, verify cratesio-mcp tools appear