### PR TITLE
feat: add audit_dependencies tool via OSV.dev API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Built with [tower-mcp](https://github.com/joshrotenberg/tower-mcp).
 
 ## Features
 
-### Tools (20)
+### Tools (21)
 
 | Tool | Description | Status |
 |------|-------------|--------|
@@ -30,7 +30,7 @@ Built with [tower-mcp](https://github.com/joshrotenberg/tower-mcp).
 | `get_crate_docs` | Browse crate documentation structure from docs.rs | Implemented |
 | `get_doc_item` | Get full docs for a specific item (fn, struct, trait) | Implemented |
 | `search_docs` | Search for items by name within a crate's docs | Implemented |
-| `audit_dependencies` | Check deps against RustSec advisory DB | [Planned (#7)](https://github.com/joshrotenberg/cratesio-mcp/issues/7) |
+| `audit_dependencies` | Check deps against OSV.dev vulnerability database | Implemented |
 
 ### Resources (2)
 
@@ -168,12 +168,12 @@ The client covers 46 endpoints across crates, versions, owners, categories, keyw
 
 - [x] Custom crates.io API client (46 endpoints)
 - [x] Library crate extraction
-- [x] 20 MCP tools
+- [x] 21 MCP tools
 - [x] Resources, prompts, and completions
 - [x] Tower middleware stack (timeout, rate limit, bulkhead, cache)
 - [x] stdio and HTTP transports
 - [x] docs.rs integration ([#2](https://github.com/joshrotenberg/cratesio-mcp/issues/2))
-- [ ] Dependency security audit via RustSec ([#7](https://github.com/joshrotenberg/cratesio-mcp/issues/7))
+- [x] Dependency security audit via OSV.dev ([#7](https://github.com/joshrotenberg/cratesio-mcp/issues/7))
 - [ ] CI pipeline ([#5](https://github.com/joshrotenberg/cratesio-mcp/issues/5))
 - [ ] Publish to crates.io ([#4](https://github.com/joshrotenberg/cratesio-mcp/issues/4))
 - [ ] Fly.io deployment ([#6](https://github.com/joshrotenberg/cratesio-mcp/issues/6))

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod docsrs;
 pub mod error;
+pub mod osv;
 pub mod query;
 pub mod types;
 pub(crate) mod wire;

--- a/src/client/osv.rs
+++ b/src/client/osv.rs
@@ -1,0 +1,309 @@
+//! OSV.dev API client for vulnerability lookups.
+//!
+//! Queries the [OSV.dev](https://osv.dev/) API to check Rust crates for known
+//! security vulnerabilities aggregated from RustSec, GHSA, and NVD.
+
+use serde::{Deserialize, Serialize};
+
+// ── Error ──────────────────────────────────────────────────────────────────
+
+/// Errors returned by the OSV.dev API client.
+#[derive(Debug, thiserror::Error)]
+pub enum OsvError {
+    /// HTTP transport error.
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// Non-200 response from the API.
+    #[error("OSV API error ({status}): {message}")]
+    Api { status: u16, message: String },
+}
+
+// ── Response types ─────────────────────────────────────────────────────────
+
+/// Top-level response from `POST /v1/query`.
+#[derive(Debug, Deserialize)]
+pub struct OsvQueryResponse {
+    pub vulns: Option<Vec<OsvVulnerability>>,
+}
+
+/// A single vulnerability record.
+#[derive(Debug, Deserialize)]
+pub struct OsvVulnerability {
+    /// Advisory ID (e.g. "RUSTSEC-2021-0078", "GHSA-...").
+    pub id: String,
+    pub summary: Option<String>,
+    pub details: Option<String>,
+    pub severity: Option<Vec<OsvSeverity>>,
+    pub affected: Option<Vec<OsvAffected>>,
+    pub references: Option<Vec<OsvReference>>,
+}
+
+/// CVSS severity information.
+#[derive(Debug, Deserialize)]
+pub struct OsvSeverity {
+    /// Severity scheme (e.g. "CVSS_V3", "CVSS_V4").
+    #[serde(rename = "type")]
+    pub severity_type: String,
+    /// CVSS vector string.
+    pub score: String,
+}
+
+/// Affected package and version range info.
+#[derive(Debug, Deserialize)]
+pub struct OsvAffected {
+    pub package: Option<OsvPackage>,
+    pub ranges: Option<Vec<OsvRange>>,
+}
+
+/// Package identifier within an ecosystem.
+#[derive(Debug, Deserialize)]
+pub struct OsvPackage {
+    pub name: String,
+    pub ecosystem: String,
+}
+
+/// A version range that is affected.
+#[derive(Debug, Deserialize)]
+pub struct OsvRange {
+    #[serde(rename = "type")]
+    pub range_type: String,
+    pub events: Vec<OsvEvent>,
+}
+
+/// A version event (introduced/fixed boundary).
+#[derive(Debug, Deserialize)]
+pub struct OsvEvent {
+    pub introduced: Option<String>,
+    pub fixed: Option<String>,
+}
+
+/// A reference link (advisory URL, etc).
+#[derive(Debug, Deserialize)]
+pub struct OsvReference {
+    #[serde(rename = "type")]
+    pub ref_type: String,
+    pub url: String,
+}
+
+// ── Request body ───────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct OsvQueryRequest<'a> {
+    package: OsvPackageQuery<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct OsvPackageQuery<'a> {
+    name: &'a str,
+    ecosystem: &'a str,
+}
+
+// ── Client ─────────────────────────────────────────────────────────────────
+
+/// Async client for the OSV.dev vulnerability API.
+pub struct OsvClient {
+    http: reqwest::Client,
+    base_url: String,
+}
+
+impl OsvClient {
+    /// Create a new client with the given user agent.
+    pub fn new(user_agent: &str) -> Result<Self, OsvError> {
+        Self::with_base_url(user_agent, "https://api.osv.dev/v1")
+    }
+
+    /// Create a new client with a custom base URL (for testing).
+    pub fn with_base_url(user_agent: &str, base_url: &str) -> Result<Self, OsvError> {
+        let http = reqwest::Client::builder().user_agent(user_agent).build()?;
+        Ok(Self {
+            http,
+            base_url: base_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    /// Query OSV for vulnerabilities affecting a specific package version.
+    pub async fn query_package(
+        &self,
+        name: &str,
+        version: &str,
+    ) -> Result<OsvQueryResponse, OsvError> {
+        let body = OsvQueryRequest {
+            package: OsvPackageQuery {
+                name,
+                ecosystem: "crates.io",
+            },
+            version: Some(version),
+        };
+        self.post_query(&body).await
+    }
+
+    /// Query OSV for all known vulnerabilities for a package (any version).
+    pub async fn query_package_any(&self, name: &str) -> Result<OsvQueryResponse, OsvError> {
+        let body = OsvQueryRequest {
+            package: OsvPackageQuery {
+                name,
+                ecosystem: "crates.io",
+            },
+            version: None,
+        };
+        self.post_query(&body).await
+    }
+
+    async fn post_query(&self, body: &OsvQueryRequest<'_>) -> Result<OsvQueryResponse, OsvError> {
+        let url = format!("{}/query", self.base_url);
+        let resp = self.http.post(&url).json(body).send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let message = resp.text().await.unwrap_or_default();
+            return Err(OsvError::Api {
+                status: status.as_u16(),
+                message,
+            });
+        }
+        Ok(resp.json().await?)
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use wiremock::matchers::{body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    fn test_client(base_url: &str) -> OsvClient {
+        OsvClient::with_base_url("test-agent", base_url).unwrap()
+    }
+
+    #[tokio::test]
+    async fn query_returns_vulnerabilities() {
+        let server = MockServer::start().await;
+
+        let response_json = serde_json::json!({
+            "vulns": [{
+                "id": "RUSTSEC-2024-0001",
+                "summary": "Test vulnerability",
+                "details": "A test vulnerability for unit testing.",
+                "severity": [{
+                    "type": "CVSS_V3",
+                    "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+                }],
+                "affected": [{
+                    "package": {
+                        "name": "some-crate",
+                        "ecosystem": "crates.io"
+                    },
+                    "ranges": [{
+                        "type": "SEMVER",
+                        "events": [
+                            { "introduced": "0" },
+                            { "fixed": "1.2.3" }
+                        ]
+                    }]
+                }],
+                "references": [{
+                    "type": "ADVISORY",
+                    "url": "https://rustsec.org/advisories/RUSTSEC-2024-0001.html"
+                }]
+            }]
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/query"))
+            .and(body_json(serde_json::json!({
+                "package": { "name": "some-crate", "ecosystem": "crates.io" },
+                "version": "1.0.0"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&response_json))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server.uri());
+        let resp = client.query_package("some-crate", "1.0.0").await.unwrap();
+
+        let vulns = resp.vulns.unwrap();
+        assert_eq!(vulns.len(), 1);
+        assert_eq!(vulns[0].id, "RUSTSEC-2024-0001");
+        assert_eq!(vulns[0].summary.as_deref(), Some("Test vulnerability"));
+
+        let severity = vulns[0].severity.as_ref().unwrap();
+        assert_eq!(severity[0].severity_type, "CVSS_V3");
+
+        let affected = vulns[0].affected.as_ref().unwrap();
+        let ranges = affected[0].ranges.as_ref().unwrap();
+        let events = &ranges[0].events;
+        assert_eq!(events[0].introduced.as_deref(), Some("0"));
+        assert_eq!(events[1].fixed.as_deref(), Some("1.2.3"));
+    }
+
+    #[tokio::test]
+    async fn query_returns_no_vulnerabilities() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server.uri());
+        let resp = client.query_package("safe-crate", "1.0.0").await.unwrap();
+
+        assert!(resp.vulns.is_none());
+    }
+
+    #[tokio::test]
+    async fn query_handles_api_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/query"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("bad request"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server.uri());
+        let err = client
+            .query_package("bad-crate", "1.0.0")
+            .await
+            .unwrap_err();
+
+        match err {
+            OsvError::Api { status, message } => {
+                assert_eq!(status, 400);
+                assert_eq!(message, "bad request");
+            }
+            other => panic!("expected Api error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn query_any_omits_version() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/query"))
+            .and(body_json(serde_json::json!({
+                "package": { "name": "some-crate", "ecosystem": "crates.io" }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "vulns": []
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = test_client(&server.uri());
+        let resp = client.query_package_any("some-crate").await.unwrap();
+
+        assert!(resp.vulns.unwrap().is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     let get_crate_docs_tool = tools::get_crate_docs::build(state.clone());
     let get_doc_item_tool = tools::get_doc_item::build(state.clone());
     let search_docs_tool = tools::search_docs::build(state.clone());
+    let audit_tool = tools::audit::build(state.clone());
 
     // Create base router with tools (always registered)
     let instructions = if args.minimal {
@@ -153,7 +154,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
          - get_keyword: Details about a specific keyword\n\
          - get_crate_docs: Browse crate documentation structure from docs.rs\n\
          - get_doc_item: Get full documentation for a specific item from docs.rs\n\
-         - search_docs: Search for items by name within a crate's docs\n\n\
+         - search_docs: Search for items by name within a crate's docs\n\
+         - audit_dependencies: Check deps against OSV.dev vulnerability database\n\n\
          (Running in minimal mode - resources, prompts, and completions disabled)"
     } else {
         "MCP server for querying crates.io - the Rust package registry.\n\n\
@@ -177,7 +179,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
          - get_keyword: Details about a specific keyword\n\
          - get_crate_docs: Browse crate documentation structure from docs.rs\n\
          - get_doc_item: Get full documentation for a specific item from docs.rs\n\
-         - search_docs: Search for items by name within a crate's docs\n\n\
+         - search_docs: Search for items by name within a crate's docs\n\
+         - audit_dependencies: Check deps against OSV.dev vulnerability database\n\n\
          Resources:\n\
          - crates://{name}/info: Get crate info as a resource\n\n\
          Use the prompts for guided analysis:\n\
@@ -207,7 +210,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .tool(keyword_detail_tool)
         .tool(get_crate_docs_tool)
         .tool(get_doc_item_tool)
-        .tool(search_docs_tool);
+        .tool(search_docs_tool)
+        .tool(audit_tool);
 
     // Add resources, prompts, and completions unless in minimal mode
     // Minimal mode works around Claude Code MCP tool discovery issues

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use crate::client::CratesIoClient;
 use crate::client::docsrs::DocsRsClient;
+use crate::client::osv::OsvClient;
 use crate::docs::cache::DocsCache;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -23,6 +24,8 @@ pub struct AppState {
     pub client: CratesIoClient,
     /// docs.rs API client for rustdoc JSON
     pub docsrs_client: DocsRsClient,
+    /// OSV.dev API client for vulnerability lookups
+    pub osv_client: OsvClient,
     /// Cache for parsed rustdoc JSON
     pub docs_cache: DocsCache,
     /// Recent search queries (exposed as a resource)
@@ -46,11 +49,14 @@ impl AppState {
             .map_err(|e| format!("Failed to create crates.io client: {e}"))?;
         let docsrs_client = DocsRsClient::new(user_agent)
             .map_err(|e| format!("Failed to create docs.rs client: {e}"))?;
+        let osv_client =
+            OsvClient::new(user_agent).map_err(|e| format!("Failed to create OSV client: {e}"))?;
         let docs_cache = DocsCache::new(docs_cache_max_entries, docs_cache_ttl);
 
         Ok(Self {
             client,
             docsrs_client,
+            osv_client,
             docs_cache,
             recent_searches: RwLock::new(Vec::new()),
         })

--- a/src/tools/audit.rs
+++ b/src/tools/audit.rs
@@ -1,0 +1,191 @@
+//! Dependency security audit tool via OSV.dev
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, ResultExt, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::client::osv::OsvVulnerability;
+use crate::state::AppState;
+
+/// Input for auditing dependencies
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AuditInput {
+    /// Crate name to audit
+    name: String,
+    /// Version to audit (default: latest)
+    version: Option<String>,
+    /// Include dev dependencies in audit
+    #[serde(default)]
+    include_dev: bool,
+}
+
+/// A vulnerability finding associated with a dependency.
+struct Finding {
+    dep_name: String,
+    vuln: OsvVulnerability,
+}
+
+fn format_findings(
+    crate_name: &str,
+    version: &str,
+    findings: &[Finding],
+    deps_checked: usize,
+) -> String {
+    let mut output = format!("# Security Audit: {} v{}\n\n", crate_name, version);
+
+    if findings.is_empty() {
+        output.push_str("No known vulnerabilities found.\n\n");
+    } else {
+        output.push_str("## Vulnerabilities Found\n\n");
+        for f in findings {
+            output.push_str(&format!("### {} -- {}\n\n", f.dep_name, f.vuln.id));
+
+            if let Some(summary) = &f.vuln.summary {
+                output.push_str(&format!("- **Summary**: {}\n", summary));
+            }
+
+            // Show CVSS severity if available
+            if let Some(severity) = &f.vuln.severity
+                && let Some(s) = severity.first()
+            {
+                output.push_str(&format!(
+                    "- **Severity**: {} ({})\n",
+                    s.severity_type, s.score
+                ));
+            }
+
+            // Show fixed version if available
+            if let Some(affected) = &f.vuln.affected {
+                for a in affected {
+                    if let Some(ranges) = &a.ranges {
+                        for range in ranges {
+                            for event in &range.events {
+                                if let Some(fixed) = &event.fixed {
+                                    output.push_str(&format!("- **Fixed in**: {}\n", fixed));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Show first advisory reference
+            if let Some(refs) = &f.vuln.references {
+                if let Some(r) = refs.iter().find(|r| r.ref_type == "ADVISORY") {
+                    output.push_str(&format!("- **Advisory**: {}\n", r.url));
+                } else if let Some(r) = refs.first() {
+                    output.push_str(&format!("- **Reference**: {}\n", r.url));
+                }
+            }
+
+            output.push('\n');
+        }
+    }
+
+    // Summary
+    let affected_deps: Vec<&str> = {
+        let mut names: Vec<&str> = findings.iter().map(|f| f.dep_name.as_str()).collect();
+        names.sort();
+        names.dedup();
+        names
+    };
+
+    output.push_str("## Summary\n\n");
+    output.push_str(&format!("- **Dependencies checked**: {}\n", deps_checked));
+    output.push_str(&format!(
+        "- **Vulnerabilities found**: {}\n",
+        findings.len()
+    ));
+    output.push_str(&format!(
+        "- **Affected dependencies**: {}\n",
+        affected_deps.len()
+    ));
+
+    output
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("audit_dependencies")
+        .description(
+            "Check a crate's dependencies against the OSV.dev vulnerability database \
+             (RustSec + GHSA + NVD). Returns known vulnerabilities for each dependency.",
+        )
+        .read_only()
+        .idempotent()
+        .icon("https://crates.io/assets/cargo.png")
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<AuditInput>| async move {
+                // Resolve crate version
+                let crate_response = state
+                    .client
+                    .get_crate(&input.name)
+                    .await
+                    .tool_context("Crates.io API error")?;
+
+                let version = input
+                    .version
+                    .as_deref()
+                    .unwrap_or(&crate_response.crate_data.max_version);
+
+                // Fetch dependencies
+                let deps = state
+                    .client
+                    .crate_dependencies(&input.name, version)
+                    .await
+                    .tool_context("Crates.io API error")?;
+
+                // Filter out dev deps unless requested
+                let deps_to_check: Vec<_> = deps
+                    .iter()
+                    .filter(|d| input.include_dev || d.kind != "dev")
+                    .collect();
+
+                let deps_checked = deps_to_check.len();
+                let mut findings = Vec::new();
+
+                // Check the crate itself
+                let self_resp = state
+                    .osv_client
+                    .query_package_any(&input.name)
+                    .await
+                    .tool_context("OSV.dev API error")?;
+
+                if let Some(vulns) = self_resp.vulns {
+                    for vuln in vulns {
+                        findings.push(Finding {
+                            dep_name: input.name.clone(),
+                            vuln,
+                        });
+                    }
+                }
+
+                // Check each dependency
+                for dep in &deps_to_check {
+                    let resp = state
+                        .osv_client
+                        .query_package_any(&dep.crate_id)
+                        .await
+                        .tool_context("OSV.dev API error")?;
+
+                    if let Some(vulns) = resp.vulns {
+                        for vuln in vulns {
+                            findings.push(Finding {
+                                dep_name: dep.crate_id.clone(),
+                                vuln,
+                            });
+                        }
+                    }
+                }
+
+                let output = format_findings(&input.name, version, &findings, deps_checked);
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Each tool corresponds to a crates.io API endpoint.
 
+pub mod audit;
 pub mod authors;
 pub mod categories;
 pub mod category;


### PR DESCRIPTION
## Summary

- Add `audit_dependencies` tool that checks a crate's dependencies against the [OSV.dev](https://osv.dev/) vulnerability database (aggregates RustSec, GHSA, and NVD advisories)
- Add `OsvClient` (`src/client/osv.rs`) with typed response structs and 4 wiremock unit tests
- Tool resolves crate version, fetches deps from crates.io, queries OSV.dev for each, and returns a formatted markdown report with severity, fix versions, and advisory links

Closes #7

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib` passes (50 tests, including 4 new OSV client tests)
- [x] `cargo test --doc` passes
- [x] `cargo run -- --help` runs successfully
- [ ] Manual: run server, call `audit_dependencies` with a crate known to have vulnerable deps