### PR TITLE
fix: decompress gzip responses from docs.rs rustdoc JSON endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "flate2",
  "reqwest",
  "rustdoc-types",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tower-mcp = { version = "0.6", features = ["http"] }
 
 # HTTP client for crates.io API
 reqwest = { version = "0.12", features = ["json", "gzip"] }
+flate2 = "1"
 rustdoc-types = "0.57"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"


### PR DESCRIPTION
## Summary

- docs.rs serves rustdoc JSON at `/crate/{name}/{version}/json.gz` with `Content-Type: application/gzip`
- reqwest only auto-decompresses `Content-Encoding: gzip` (transport-level), not `Content-Type: application/gzip` (resource-level)
- The raw gzip bytes were passed directly to serde, causing `expected value at line 1 column 1` on every crate
- Add `flate2` to decompress when gzip magic bytes (`0x1f 0x8b`) are detected
- Add `DocsRsError::Decompress` variant for gzip-specific failures
- Plain JSON responses (non-gzip) continue to work via the magic byte check

## Test plan

- [x] New test: `fetch_rustdoc_gzip_response` -- mock returns gzip-compressed JSON
- [x] Renamed test: `fetch_rustdoc_plain_json_response` -- mock returns plain JSON (regression)
- [x] Existing tests pass (parse error, not found, not available)
- [ ] Manual: run server and test `get_crate_docs`, `get_doc_item`, `search_docs` against live docs.rs

Closes #19
Also fixes #20, #21