### PR TITLE
docs: add LICENSE files and clean up README

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,199 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to the Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by the Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding any notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. Please also get an
+   OpenPGP-compatible signature of the boilerplate notice.
+
+   Copyright 2026 Josh Rotenberg
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Josh Rotenberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,29 +8,29 @@ Built with [tower-mcp](https://github.com/joshrotenberg/tower-mcp).
 
 ### Tools (21)
 
-| Tool | Description | Status |
-|------|-------------|--------|
-| `search_crates` | Search for crates by name or keywords | Implemented |
-| `get_crate_info` | Detailed crate metadata (description, links, stats) | Implemented |
-| `get_crate_versions` | Version history with release dates and download counts | Implemented |
-| `get_crate_readme` | README content for a crate version | Implemented |
-| `get_dependencies` | Dependencies for a specific version | Implemented |
-| `get_reverse_dependencies` | Crates that depend on a given crate | Implemented |
-| `get_downloads` | Download statistics and trends | Implemented |
-| `get_crate_authors` | Authors listed in Cargo.toml | Implemented |
-| `get_owners` | Crate owners and maintainers | Implemented |
-| `get_user` | User profile by GitHub username | Implemented |
-| `get_summary` | crates.io global statistics | Implemented |
-| `get_categories` | Browse crates.io categories | Implemented |
-| `get_category` | Details for a specific category | Implemented |
-| `get_keywords` | Browse crates.io keywords | Implemented |
-| `get_keyword` | Details for a specific keyword | Implemented |
-| `get_version_downloads` | Daily download stats for a specific version | Implemented |
-| `get_crate_version` | Detailed metadata for a specific version | Implemented |
-| `get_crate_docs` | Browse crate documentation structure from docs.rs | Implemented |
-| `get_doc_item` | Get full docs for a specific item (fn, struct, trait) | Implemented |
-| `search_docs` | Search for items by name within a crate's docs | Implemented |
-| `audit_dependencies` | Check deps against OSV.dev vulnerability database | Implemented |
+| Tool | Description |
+|------|-------------|
+| `search_crates` | Search for crates by name or keywords |
+| `get_crate_info` | Detailed crate metadata (description, links, stats) |
+| `get_crate_versions` | Version history with release dates and download counts |
+| `get_crate_readme` | README content for a crate version |
+| `get_dependencies` | Dependencies for a specific version |
+| `get_reverse_dependencies` | Crates that depend on a given crate |
+| `get_downloads` | Download statistics and trends |
+| `get_crate_authors` | Authors listed in Cargo.toml |
+| `get_owners` | Crate owners and maintainers |
+| `get_user` | User profile by GitHub username |
+| `get_summary` | crates.io global statistics |
+| `get_categories` | Browse crates.io categories |
+| `get_category` | Details for a specific category |
+| `get_keywords` | Browse crates.io keywords |
+| `get_keyword` | Details for a specific keyword |
+| `get_version_downloads` | Daily download stats for a specific version |
+| `get_crate_version` | Detailed metadata for a specific version |
+| `get_crate_docs` | Browse crate documentation structure from docs.rs |
+| `get_doc_item` | Get full docs for a specific item (fn, struct, trait) |
+| `search_docs` | Search for items by name within a crate's docs |
+| `audit_dependencies` | Check deps against OSV.dev vulnerability database |
 
 ### Resources (2)
 
@@ -67,11 +67,7 @@ The HTTP transport includes a tower middleware stack:
 
 ## Installation
 
-```bash
-cargo install cratesio-mcp
-```
-
-Or build from source:
+Build from source:
 
 ```bash
 git clone https://github.com/joshrotenberg/cratesio-mcp
@@ -93,23 +89,46 @@ cratesio-mcp
 cratesio-mcp --transport http --port 3000
 ```
 
+### Minimal mode
+
+Use `--minimal` to register only tools (no prompts, resources, or completions). This is useful for Claude Code, which currently has issues discovering tools when prompts and resources are also registered ([anthropics/claude-code#2682](https://github.com/anthropics/claude-code/issues/2682)).
+
+```bash
+cratesio-mcp --minimal
+```
+
 ### CLI options
 
 ```text
+Usage: cratesio-mcp [OPTIONS]
+
 Options:
-  -t, --transport <TRANSPORT>              Transport: stdio or http [default: stdio]
-      --max-concurrent <N>                 Max concurrent requests [default: 10]
-      --rate-limit-ms <MS>                 Rate limit interval in ms [default: 1000]
-  -l, --log-level <LEVEL>                  Log level [default: info]
-      --host <HOST>                        HTTP bind address [default: 127.0.0.1]
-  -p, --port <PORT>                        HTTP port [default: 3000]
-      --request-timeout-secs <S>           Request timeout [default: 30]
-      --minimal                            Tools only (no prompts/resources/completions)
-      --cache-enabled                      Enable response caching [default: true]
-      --cache-ttl-secs <S>                 Cache TTL [default: 300]
-      --cache-max-size <N>                 Max cached responses [default: 200]
-      --docs-cache-max-entries <N>         Max cached docs.rs entries [default: 10]
-      --docs-cache-ttl-secs <S>            docs.rs cache TTL [default: 3600]
+  -t, --transport <TRANSPORT>
+          Transport to use [default: stdio] [possible values: stdio, http]
+      --max-concurrent <MAX_CONCURRENT>
+          Maximum concurrent requests (concurrency limit) [default: 10]
+      --rate-limit-ms <RATE_LIMIT_MS>
+          Rate limit interval between crates.io API calls (in milliseconds) [default: 1000]
+  -l, --log-level <LOG_LEVEL>
+          Log level [default: info]
+      --host <HOST>
+          HTTP host to bind to (use 0.0.0.0 for public access) [default: 127.0.0.1]
+  -p, --port <PORT>
+          HTTP port to bind to [default: 3000]
+      --request-timeout-secs <REQUEST_TIMEOUT_SECS>
+          Request timeout in seconds (for HTTP transport) [default: 30]
+      --minimal
+          Minimal mode - only register tools (no prompts, resources, or completions)
+      --cache-enabled
+          Enable response caching for tool calls (HTTP transport only)
+      --cache-ttl-secs <CACHE_TTL_SECS>
+          Cache TTL in seconds (how long cached responses are valid) [default: 300]
+      --cache-max-size <CACHE_MAX_SIZE>
+          Maximum number of cached responses [default: 200]
+      --docs-cache-max-entries <DOCS_CACHE_MAX_ENTRIES>
+          Maximum number of cached docs.rs rustdoc JSON entries [default: 10]
+      --docs-cache-ttl-secs <DOCS_CACHE_TTL_SECS>
+          TTL for cached docs.rs rustdoc JSON entries (in seconds) [default: 3600]
 ```
 
 ## MCP client configuration
@@ -172,11 +191,14 @@ The client covers 46 endpoints across crates, versions, owners, categories, keyw
 - [x] Resources, prompts, and completions
 - [x] Tower middleware stack (timeout, rate limit, bulkhead, cache)
 - [x] stdio and HTTP transports
+- [x] CI pipeline ([#5](https://github.com/joshrotenberg/cratesio-mcp/issues/5))
 - [x] docs.rs integration ([#2](https://github.com/joshrotenberg/cratesio-mcp/issues/2))
 - [x] Dependency security audit via OSV.dev ([#7](https://github.com/joshrotenberg/cratesio-mcp/issues/7))
-- [ ] CI pipeline ([#5](https://github.com/joshrotenberg/cratesio-mcp/issues/5))
 - [ ] Publish to crates.io ([#4](https://github.com/joshrotenberg/cratesio-mcp/issues/4))
 - [ ] Fly.io deployment ([#6](https://github.com/joshrotenberg/cratesio-mcp/issues/6))
+- [ ] Feature flag analysis tool ([#15](https://github.com/joshrotenberg/cratesio-mcp/issues/15))
+- [ ] New resources: readme, docs ([#16](https://github.com/joshrotenberg/cratesio-mcp/issues/16))
+- [ ] User download stats tool ([#18](https://github.com/joshrotenberg/cratesio-mcp/issues/18))
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add `LICENSE-MIT` and `LICENSE-APACHE` files to match the `license = "MIT OR Apache-2.0"` declaration in Cargo.toml
- Remove redundant "Status" column from tools table (everything is implemented)
- Remove `cargo install` instruction since the crate is not yet published (#4)
- Add `--minimal` mode documentation with link to the Claude Code issue it works around
- Update CLI options section to match actual `--help` output
- Fix roadmap: mark CI (#5) and audit (#7) as done, add open issues #15, #16, #18

## Test plan

- [ ] `cargo package --list --allow-dirty` includes both LICENSE files
- [ ] CI passes (no code changes)