### PR TITLE
feat: add get_user_stats tool for user download statistics

### DIFF
--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -641,6 +641,7 @@ async fn user_parses_response() {
         .and(path("/users/joshrotenberg"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "user": {
+                "id": 12345,
                 "login": "joshrotenberg",
                 "name": "Josh Rotenberg",
                 "url": "https://github.com/joshrotenberg",
@@ -655,6 +656,7 @@ async fn user_parses_response() {
     let client = test_client(&server.uri());
     let user = client.user("joshrotenberg").await.unwrap();
 
+    assert_eq!(user.id, 12345);
     assert_eq!(user.login, "joshrotenberg");
     assert_eq!(user.name.as_deref(), Some("Josh Rotenberg"));
     assert_eq!(user.kind.as_deref(), Some("user"));
@@ -995,6 +997,7 @@ async fn auth_header_sent_on_authenticated_request() {
         .and(header("Authorization", "my-secret-token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "user": {
+                "id": 99999,
                 "login": "testuser",
                 "name": "Test User",
                 "url": "https://github.com/testuser",

--- a/src/client/types.rs
+++ b/src/client/types.rs
@@ -63,6 +63,7 @@ pub struct VersionDownloads {
 /// User or team on crates.io.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
+    pub id: u64,
     pub login: String,
     #[serde(default)]
     pub name: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     let search_docs_tool = tools::search_docs::build(state.clone());
     let audit_tool = tools::audit::build(state.clone());
     let features_tool = tools::features::build(state.clone());
+    let user_stats_tool = tools::user_stats::build(state.clone());
 
     // Create base router with tools (always registered)
     let instructions = if args.minimal {
@@ -157,7 +158,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
          - get_doc_item: Get full documentation for a specific item from docs.rs\n\
          - search_docs: Search for items by name within a crate's docs\n\
          - audit_dependencies: Check deps against OSV.dev vulnerability database\n\
-         - get_crate_features: Get feature flags for a crate version\n\n\
+         - get_crate_features: Get feature flags for a crate version\n\
+         - get_user_stats: Get download statistics for a crates.io user\n\n\
          (Running in minimal mode - resources, prompts, and completions disabled)"
     } else {
         "MCP server for querying crates.io - the Rust package registry.\n\n\
@@ -183,7 +185,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
          - get_doc_item: Get full documentation for a specific item from docs.rs\n\
          - search_docs: Search for items by name within a crate's docs\n\
          - audit_dependencies: Check deps against OSV.dev vulnerability database\n\
-         - get_crate_features: Get feature flags for a crate version\n\n\
+         - get_crate_features: Get feature flags for a crate version\n\
+         - get_user_stats: Get download statistics for a crates.io user\n\n\
          Resources:\n\
          - crates://{name}/info: Get crate info as a resource\n\
          - crates://{name}/readme: Get README content for a crate\n\
@@ -217,7 +220,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .tool(get_doc_item_tool)
         .tool(search_docs_tool)
         .tool(audit_tool)
-        .tool(features_tool);
+        .tool(features_tool)
+        .tool(user_stats_tool);
 
     // Add resources, prompts, and completions unless in minimal mode
     // Minimal mode works around Claude Code MCP tool discovery issues

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -21,6 +21,7 @@ pub mod search;
 pub mod search_docs;
 pub mod summary;
 pub mod user;
+pub mod user_stats;
 pub mod version_detail;
 pub mod version_downloads;
 pub mod versions;

--- a/src/tools/user_stats.rs
+++ b/src/tools/user_stats.rs
@@ -1,0 +1,59 @@
+//! Get user download stats tool
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, ResultExt, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::state::{AppState, format_number};
+
+/// Input for getting user download statistics
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UserStatsInput {
+    /// GitHub username
+    username: String,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_user_stats")
+        .description(
+            "Get download statistics for a crates.io user. \
+             Shows total downloads across all of the user's crates.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<UserStatsInput>| async move {
+                let user = state
+                    .client
+                    .user(&input.username)
+                    .await
+                    .tool_context("Crates.io API error")?;
+
+                let stats = state
+                    .client
+                    .user_stats(user.id)
+                    .await
+                    .tool_context("Crates.io API error")?;
+
+                let mut output = format!("# User Stats: {}\n\n", user.login);
+
+                if let Some(name) = &user.name {
+                    output.push_str(&format!("**Name:** {}\n\n", name));
+                }
+
+                output.push_str(&format!(
+                    "**Total downloads:** {}\n",
+                    format_number(stats.total_downloads)
+                ));
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}


### PR DESCRIPTION
## Summary

- Adds `get_user_stats` MCP tool that accepts a `username` parameter, resolves it to a numeric user ID via the existing `/users/{login}` endpoint, then fetches download stats from `/users/{id}/stats`
- Adds `id: u64` field to the `User` type to enable the username-to-ID lookup
- Includes integration test (wiremock) and updates existing user mock JSON to include the `id` field

Closes #18

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib --all-features` passes (92 tests)
- [x] `cargo test --test '*' --all-features` passes (28 tests, including new `tool_get_user_stats`)