### PR TITLE
fix: add profile.dist for cargo-dist builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,8 @@ tower-resilience = { version = "0.7.1", default-features = false, features = ["b
 
 [dev-dependencies]
 wiremock = "0.6"
+
+# The profile that 'dist' will build with
+[profile.dist]
+inherits = "release"
+lto = "thin"


### PR DESCRIPTION
## Summary

Add missing `[profile.dist]` section to Cargo.toml. cargo-dist requires this profile to exist -- without it, builds fail with `error: profile 'dist' is not defined`.

## Test plan

- [ ] Merge and verify next release tag triggers successful cargo-dist builds