### PR TITLE
feat: add compare_crates tool for side-by-side crate comparison

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     let audit_tool = tools::audit::build(state.clone());
     let features_tool = tools::features::build(state.clone());
     let user_stats_tool = tools::user_stats::build(state.clone());
+    let compare_tool = tools::compare::build(state.clone());
 
     // Create base router with tools (always registered)
     let instructions = if args.minimal {
@@ -159,7 +160,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
          - search_docs: Search for items by name within a crate's docs\n\
          - audit_dependencies: Check deps against OSV.dev vulnerability database\n\
          - get_crate_features: Get feature flags for a crate version\n\
-         - get_user_stats: Get download statistics for a crates.io user\n\n\
+         - get_user_stats: Get download statistics for a crates.io user\n\
+         - compare_crates: Compare two or more crates side by side\n\n\
          (Running in minimal mode - resources, prompts, and completions disabled)"
     } else {
         "MCP server for querying crates.io - the Rust package registry.\n\n\
@@ -186,7 +188,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
          - search_docs: Search for items by name within a crate's docs\n\
          - audit_dependencies: Check deps against OSV.dev vulnerability database\n\
          - get_crate_features: Get feature flags for a crate version\n\
-         - get_user_stats: Get download statistics for a crates.io user\n\n\
+         - get_user_stats: Get download statistics for a crates.io user\n\
+         - compare_crates: Compare two or more crates side by side\n\n\
          Resources:\n\
          - crates://{name}/info: Get crate info as a resource\n\
          - crates://{name}/readme: Get README content for a crate\n\
@@ -221,7 +224,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .tool(search_docs_tool)
         .tool(audit_tool)
         .tool(features_tool)
-        .tool(user_stats_tool);
+        .tool(user_stats_tool)
+        .tool(compare_tool);
 
     // Add resources, prompts, and completions unless in minimal mode
     // Minimal mode works around Claude Code MCP tool discovery issues

--- a/src/tools/compare.rs
+++ b/src/tools/compare.rs
@@ -1,0 +1,159 @@
+//! Compare crates tool
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::state::{AppState, format_number};
+
+/// Input for comparing crates
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CompareInput {
+    /// Comma-separated list of crate names to compare (2-5 crates)
+    crates: String,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("compare_crates")
+        .description(
+            "Compare two or more crates side by side. Returns a structured comparison of \
+             downloads, versions, dependencies, reverse dependencies, and freshness.",
+        )
+        .read_only()
+        .idempotent()
+        .icon("https://crates.io/assets/cargo.png")
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<CompareInput>| async move {
+                let names: Vec<&str> = input.crates.split(',').map(|s| s.trim()).collect();
+
+                if names.len() < 2 {
+                    return Ok(CallToolResult::text(
+                        "Please provide at least 2 crate names separated by commas.",
+                    ));
+                }
+                if names.len() > 5 {
+                    return Ok(CallToolResult::text(
+                        "Please provide at most 5 crate names to compare.",
+                    ));
+                }
+
+                let mut output = format!("# Crate Comparison: {}\n\n", names.join(" vs "));
+
+                // Table header
+                output.push_str("| | ");
+                for name in &names {
+                    output.push_str(&format!("**{}** | ", name));
+                }
+                output.push('\n');
+
+                output.push_str("|---|");
+                for _ in &names {
+                    output.push_str("---|");
+                }
+                output.push('\n');
+
+                // Gather data for each crate
+                let mut versions_row = vec![];
+                let mut downloads_row = vec![];
+                let mut recent_row = vec![];
+                let mut deps_row = vec![];
+                let mut rev_deps_row = vec![];
+                let mut last_release_row = vec![];
+                let mut license_row = vec![];
+                let mut msrv_row = vec![];
+                let mut description_row = vec![];
+
+                for name in &names {
+                    let info = state.client.get_crate(name).await;
+                    let rev_deps = state.client.crate_reverse_dependencies(name).await;
+
+                    match info {
+                        Ok(resp) => {
+                            let c = &resp.crate_data;
+                            versions_row.push(c.max_version.clone());
+                            downloads_row.push(format_number(c.downloads));
+                            recent_row.push(
+                                c.recent_downloads
+                                    .map(format_number)
+                                    .unwrap_or_else(|| "-".to_string()),
+                            );
+                            last_release_row.push(c.updated_at.date_naive().to_string());
+                            description_row
+                                .push(c.description.clone().unwrap_or_else(|| "-".to_string()));
+
+                            // Get deps and version details from the latest version
+                            let version = &c.max_version;
+                            match state.client.crate_dependencies(name, version).await {
+                                Ok(deps) => {
+                                    let normal: Vec<_> = deps
+                                        .iter()
+                                        .filter(|d| d.kind == "normal" && !d.optional)
+                                        .collect();
+                                    deps_row.push(format!("{}", normal.len()));
+                                }
+                                Err(_) => deps_row.push("-".to_string()),
+                            }
+
+                            match state.client.crate_version(name, version).await {
+                                Ok(v) => {
+                                    license_row.push(v.license.unwrap_or_else(|| "-".to_string()));
+                                    msrv_row
+                                        .push(v.rust_version.unwrap_or_else(|| "-".to_string()));
+                                }
+                                Err(_) => {
+                                    license_row.push("-".to_string());
+                                    msrv_row.push("-".to_string());
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            let err = format!("error: {}", e);
+                            versions_row.push(err.clone());
+                            downloads_row.push(err.clone());
+                            recent_row.push(err.clone());
+                            deps_row.push(err.clone());
+                            last_release_row.push(err.clone());
+                            license_row.push(err.clone());
+                            msrv_row.push(err.clone());
+                            description_row.push(err);
+                        }
+                    }
+
+                    match rev_deps {
+                        Ok(rd) => rev_deps_row.push(format!("{}", rd.meta.total)),
+                        Err(_) => rev_deps_row.push("-".to_string()),
+                    }
+                }
+
+                // Build table rows
+                let rows = [
+                    ("Description", &description_row),
+                    ("Latest Version", &versions_row),
+                    ("Total Downloads", &downloads_row),
+                    ("Recent Downloads", &recent_row),
+                    ("Direct Deps", &deps_row),
+                    ("Reverse Deps", &rev_deps_row),
+                    ("Last Release", &last_release_row),
+                    ("License", &license_row),
+                    ("MSRV", &msrv_row),
+                ];
+
+                for (label, values) in &rows {
+                    output.push_str(&format!("| {} | ", label));
+                    for val in *values {
+                        output.push_str(&format!("{} | ", val));
+                    }
+                    output.push('\n');
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
+        .build()
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -6,6 +6,7 @@ pub mod audit;
 pub mod authors;
 pub mod categories;
 pub mod category;
+pub mod compare;
 pub mod crate_docs;
 pub mod dependencies;
 pub mod doc_item;


### PR DESCRIPTION
## Summary

- Adds `compare_crates` tool that compares 2-5 crates in a markdown table
- Compares: description, latest version, total/recent downloads, direct deps, reverse deps, last release, license, MSRV
- Includes integration tests (full comparison + validation of minimum crate count)

Closes #44