### PR TITLE
fix: disable GitHub release creation in release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -13,6 +13,7 @@ pr_draft = false
 publish = true
 
 # Git settings
-git_release_enable = true
-git_release_draft = false
+# cargo-dist creates the GitHub Release (with binaries attached),
+# so release-plz only creates the tag to trigger the cargo-dist workflow.
+git_release_enable = false
 git_tag_enable = true


### PR DESCRIPTION
## Summary

- Disables `git_release_enable` in release-plz so cargo-dist owns GitHub Release creation
- release-plz still creates the git tag, which triggers cargo-dist to build binaries and create the release with artifacts attached
- Fixes the `a release with the same tag name already exists: v0.1.2` error from cargo-dist

## To fix v0.1.2

After merging, delete the empty v0.1.2 release and re-run the cargo-dist workflow (or let the next release go through cleanly).