### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - 2026-02-24
+
+### Bug Fixes
+
+- Disable GitHub release creation in release-plz ([#50](https://github.com/joshrotenberg/cratesio-mcp/pull/50))
+
+### Features
+
+- Add compare_crates tool for side-by-side crate comparison ([#49](https://github.com/joshrotenberg/cratesio-mcp/pull/49))
+- Add get_dependency_tree tool for recursive transitive deps ([#45](https://github.com/joshrotenberg/cratesio-mcp/pull/45)) ([#52](https://github.com/joshrotenberg/cratesio-mcp/pull/52))
+- Add crate_health_check composite tool ([#53](https://github.com/joshrotenberg/cratesio-mcp/pull/53)) ([#56](https://github.com/joshrotenberg/cratesio-mcp/pull/56))
+
+
+
 ## [0.1.2] - 2026-02-24
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "cratesio-mcp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cratesio-mcp"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP server for querying crates.io - the Rust package registry"


### PR DESCRIPTION



## 🤖 New release

* `cratesio-mcp`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3] - 2026-02-24

### Bug Fixes

- Disable GitHub release creation in release-plz ([#50](https://github.com/joshrotenberg/cratesio-mcp/pull/50))

### Features

- Add compare_crates tool for side-by-side crate comparison ([#49](https://github.com/joshrotenberg/cratesio-mcp/pull/49))
- Add get_dependency_tree tool for recursive transitive deps ([#45](https://github.com/joshrotenberg/cratesio-mcp/pull/45)) ([#52](https://github.com/joshrotenberg/cratesio-mcp/pull/52))
- Add crate_health_check composite tool ([#53](https://github.com/joshrotenberg/cratesio-mcp/pull/53)) ([#56](https://github.com/joshrotenberg/cratesio-mcp/pull/56))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).