### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - 2026-03-19
+
+### Features
+
+- Upgrade tower-mcp to 0.9.1 and enable optional_sessions for HTTP transport ([#63](https://github.com/joshrotenberg/cratesio-mcp/pull/63))
+- Add evaluate_dependencies prompt (closes #57) ([#66](https://github.com/joshrotenberg/cratesio-mcp/pull/66))
+- Add recommend_crates prompt (closes #58) ([#67](https://github.com/joshrotenberg/cratesio-mcp/pull/67))
+- Add migration_guide prompt (closes #59) ([#68](https://github.com/joshrotenberg/cratesio-mcp/pull/68))
+- Add retry with exponential backoff for outbound API calls (closes #42) ([#70](https://github.com/joshrotenberg/cratesio-mcp/pull/70))
+- Add find_alternatives tool (closes #54) ([#71](https://github.com/joshrotenberg/cratesio-mcp/pull/71))
+
+
+
 ## [0.1.3] - 2026-02-24
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "cratesio-mcp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cratesio-mcp"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP server for querying crates.io - the Rust package registry"


### PR DESCRIPTION



## 🤖 New release

* `cratesio-mcp`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4] - 2026-03-19

### Features

- Upgrade tower-mcp to 0.9.1 and enable optional_sessions for HTTP transport ([#63](https://github.com/joshrotenberg/cratesio-mcp/pull/63))
- Add evaluate_dependencies prompt (closes #57) ([#66](https://github.com/joshrotenberg/cratesio-mcp/pull/66))
- Add recommend_crates prompt (closes #58) ([#67](https://github.com/joshrotenberg/cratesio-mcp/pull/67))
- Add migration_guide prompt (closes #59) ([#68](https://github.com/joshrotenberg/cratesio-mcp/pull/68))
- Add retry with exponential backoff for outbound API calls (closes #42) ([#70](https://github.com/joshrotenberg/cratesio-mcp/pull/70))
- Add find_alternatives tool (closes #54) ([#71](https://github.com/joshrotenberg/cratesio-mcp/pull/71))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).