### PR TITLE
Add migration_guide prompt

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
          - compare_crates: Compare multiple crates\n\
          - stack_review: Evaluate a set of crates as a cohesive stack\n\
          - evaluate_dependencies: Evaluate project dependencies for health and security\n\
-         - recommend_crates: Find and evaluate crates for a use case"
+         - recommend_crates: Find and evaluate crates for a use case\n\
+         - migration_guide: Generate a migration guide between two crates"
     };
 
     let mut router = McpRouter::new()
@@ -254,6 +255,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         let stack_review_prompt = prompts::stack_review::build();
         let evaluate_dependencies_prompt = prompts::evaluate_dependencies::build();
         let recommend_prompt = prompts::recommend::build();
+        let migration_guide_prompt = prompts::migration_guide::build();
 
         // Popular crates for completion suggestions
         let popular_crates = vec![
@@ -302,6 +304,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             .prompt(stack_review_prompt)
             .prompt(evaluate_dependencies_prompt)
             .prompt(recommend_prompt)
+            .prompt(migration_guide_prompt)
             // Completion handler for crate name suggestions
             .completion_handler(move |params: CompleteParams| {
                 let popular = popular_crates.clone();

--- a/src/prompts/migration_guide.rs
+++ b/src/prompts/migration_guide.rs
@@ -1,0 +1,63 @@
+//! Migration guide prompt
+
+use std::collections::HashMap;
+
+use tower_mcp::{GetPromptResult, Prompt, PromptBuilder, PromptMessage, PromptRole};
+
+pub fn build() -> Prompt {
+    PromptBuilder::new("migration_guide")
+        .description("Generate a migration guide for switching between two crates")
+        .required_arg("from_crate", "The crate being replaced")
+        .required_arg("to_crate", "The crate being adopted")
+        .handler(|args: HashMap<String, String>| async move {
+            let from_crate = args
+                .get("from_crate")
+                .map(|s| s.as_str())
+                .unwrap_or("unknown");
+            let to_crate = args
+                .get("to_crate")
+                .map(|s| s.as_str())
+                .unwrap_or("unknown");
+
+            let prompt = format!(
+                "Please generate a migration guide for switching from '{}' to '{}'.\n\n\
+                 Use the available tools to gather data:\n\
+                 - compare_crates on both crates to get a side-by-side overview\n\
+                 - get_crate_docs for '{}' to understand its API surface\n\
+                 - get_crate_docs for '{}' to understand its API surface\n\n\
+                 Then analyze and document the following:\n\n\
+                 1. **Dependencies**: Compare dependency counts and notable differences\n\
+                 2. **Features**: Feature flags available in each crate and equivalents\n\
+                 3. **MSRV**: Minimum Supported Rust Version for each crate\n\
+                 4. **License**: License compatibility concerns\n\
+                 5. **Key Differences**: API changes, renamed types/functions, removed or added concepts\n\
+                 6. **Migration Concerns**: Breaking changes, behavioral differences, known pitfalls\n\n\
+                 Produce a structured migration guide with step-by-step instructions for \
+                 switching from '{}' to '{}'.",
+                from_crate,
+                to_crate,
+                from_crate,
+                to_crate,
+                from_crate,
+                to_crate,
+            );
+
+            Ok(GetPromptResult {
+                description: Some(format!(
+                    "Migration guide from '{}' to '{}'",
+                    from_crate, to_crate
+                )),
+                messages: vec![PromptMessage {
+                    role: PromptRole::User,
+                    content: tower_mcp::protocol::Content::Text {
+                        text: prompt,
+                        annotations: None,
+                        meta: None,
+                    },
+                    meta: None,
+                }],
+                meta: None,
+            })
+        })
+        .build()
+}

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -3,5 +3,6 @@
 pub mod analyze;
 pub mod compare;
 pub mod evaluate_dependencies;
+pub mod migration_guide;
 pub mod recommend;
 pub mod stack_review;


### PR DESCRIPTION
## Summary

- Adds migration_guide prompt that guides LLM to compare two crates and produce a migration guide

Closes #59

## Test plan

- [x] cargo fmt
- [x] cargo clippy (no warnings)
- [x] cargo test --lib (106 passed)