### PR TITLE
feat: add retry with exponential backoff for outbound API calls

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -58,12 +58,15 @@ impl std::fmt::Debug for Auth {
 ///
 /// Includes built-in rate limiting to respect the crates.io crawling policy.
 /// Supports optional authentication via API token for write operations.
+/// Retries transient failures (429, 5xx) with exponential backoff.
 pub struct CratesIoClient {
     http: reqwest::Client,
     base_url: String,
     rate_limit: Duration,
     last_request: Arc<Mutex<Option<Instant>>>,
     auth: Option<Auth>,
+    max_retries: u32,
+    initial_backoff: Duration,
 }
 
 impl CratesIoClient {
@@ -85,7 +88,25 @@ impl CratesIoClient {
             rate_limit,
             last_request: Arc::new(Mutex::new(None)),
             auth: None,
+            max_retries: 3,
+            initial_backoff: Duration::from_millis(500),
         })
+    }
+
+    /// Set the maximum number of retries for transient failures.
+    ///
+    /// Returns `self` for builder-style chaining.
+    pub fn with_max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    /// Set the initial backoff duration for exponential retry backoff.
+    ///
+    /// Returns `self` for builder-style chaining.
+    pub fn with_initial_backoff(mut self, backoff: Duration) -> Self {
+        self.initial_backoff = backoff;
+        self
     }
 
     /// Enable authentication with an API token.
@@ -120,12 +141,53 @@ impl CratesIoClient {
         *last = Some(Instant::now());
     }
 
+    /// Execute an HTTP request with exponential backoff retry on 429 and 5xx responses.
+    ///
+    /// `make_request` is called once per attempt. Retries are only performed for
+    /// transient failures (429 Too Many Requests, 5xx Server Error). Client errors
+    /// (4xx other than 429) are returned immediately without retrying.
+    async fn send_with_retry<F, Fut>(
+        &self,
+        path: &str,
+        make_request: F,
+    ) -> Result<reqwest::Response, Error>
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = Result<reqwest::Response, reqwest::Error>>,
+    {
+        let mut attempt = 0u32;
+        loop {
+            self.throttle().await;
+            let resp = make_request().await?;
+            let status = resp.status();
+
+            let retryable =
+                status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error();
+
+            if retryable && attempt < self.max_retries {
+                let backoff = self.initial_backoff * 2u32.pow(attempt);
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    max_retries = self.max_retries,
+                    status = status.as_u16(),
+                    path,
+                    backoff_ms = backoff.as_millis(),
+                    "retrying crates.io request"
+                );
+                tokio::time::sleep(backoff).await;
+                attempt += 1;
+                continue;
+            }
+
+            return Self::check_status(resp, path).await;
+        }
+    }
+
     /// Send a GET request and check the response status.
     pub(crate) async fn send(&self, path: &str) -> Result<reqwest::Response, Error> {
-        self.throttle().await;
         let url = format!("{}{}", self.base_url, path);
-        let resp = self.http.get(&url).send().await?;
-        Self::check_status(resp, path).await
+        self.send_with_retry(path, || self.http.get(&url).send())
+            .await
     }
 
     /// Send a GET request with query parameters and check the response status.
@@ -134,10 +196,9 @@ impl CratesIoClient {
         path: &str,
         query: &[(String, String)],
     ) -> Result<reqwest::Response, Error> {
-        self.throttle().await;
         let url = format!("{}{}", self.base_url, path);
-        let resp = self.http.get(&url).query(query).send().await?;
-        Self::check_status(resp, path).await
+        self.send_with_retry(path, || self.http.get(&url).query(query).send())
+            .await
     }
 
     /// Map non-success HTTP status codes to typed errors.
@@ -191,16 +252,12 @@ impl CratesIoClient {
 
     /// Send an authenticated GET request.
     pub(crate) async fn send_auth(&self, path: &str) -> Result<reqwest::Response, Error> {
-        let token = self.require_auth()?;
-        self.throttle().await;
+        let token = self.require_auth()?.to_string();
         let url = format!("{}{}", self.base_url, path);
-        let resp = self
-            .http
-            .get(&url)
-            .header("Authorization", token)
-            .send()
-            .await?;
-        Self::check_status(resp, path).await
+        self.send_with_retry(path, || {
+            self.http.get(&url).header("Authorization", &token).send()
+        })
+        .await
     }
 
     /// Send an authenticated GET request with query parameters.

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -8,9 +8,19 @@ use super::types::{
     CrateSettings, NewGitHubConfig, NewGitLabConfig, PublishMetadata, VersionSettings,
 };
 
-/// Create a client pointed at the mock server with no rate limiting.
+/// Create a client pointed at the mock server with no rate limiting and retries disabled.
 fn test_client(base_url: &str) -> CratesIoClient {
-    CratesIoClient::with_base_url("test-agent", Duration::from_millis(0), base_url).unwrap()
+    CratesIoClient::with_base_url("test-agent", Duration::from_millis(0), base_url)
+        .unwrap()
+        .with_max_retries(0)
+}
+
+/// Create a client with retries enabled and zero backoff (for fast tests).
+fn test_retry_client(base_url: &str) -> CratesIoClient {
+    CratesIoClient::with_base_url("test-agent", Duration::from_millis(0), base_url)
+        .unwrap()
+        .with_max_retries(3)
+        .with_initial_backoff(Duration::from_millis(0))
 }
 
 // ── get_crate ───────────────────────────────────────────────────────────────
@@ -1707,6 +1717,97 @@ async fn exchange_oidc_token_sends_post() {
     let token = client.exchange_oidc_token("my-jwt").await.unwrap();
 
     assert_eq!(token, "cio-publish-token-abc");
+}
+
+// ── retry ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn retry_succeeds_after_transient_500() {
+    let server = MockServer::start().await;
+
+    // Success response (lowest priority — matched after the 500 is consumed).
+    Mock::given(method("GET"))
+        .and(path("/summary"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(SUMMARY_JSON, "application/json"))
+        .mount(&server)
+        .await;
+
+    // 500 on first attempt only (highest priority — matched first).
+    Mock::given(method("GET"))
+        .and(path("/summary"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    let client = test_retry_client(&server.uri());
+    let summary = client.summary().await.unwrap();
+
+    assert_eq!(summary.num_crates, 180000);
+}
+
+#[tokio::test]
+async fn retry_succeeds_after_429() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/summary"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(SUMMARY_JSON, "application/json"))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/summary"))
+        .respond_with(ResponseTemplate::new(429))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    let client = test_retry_client(&server.uri());
+    let summary = client.summary().await.unwrap();
+
+    assert_eq!(summary.num_crates, 180000);
+}
+
+#[tokio::test]
+async fn gives_up_after_max_retries() {
+    let server = MockServer::start().await;
+
+    // Always returns 500 — client should exhaust retries and surface the error.
+    Mock::given(method("GET"))
+        .and(path("/summary"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+        .mount(&server)
+        .await;
+
+    let client = test_retry_client(&server.uri());
+    let err = client.summary().await.unwrap_err();
+
+    assert!(
+        matches!(err, super::Error::Api { status: 500, .. }),
+        "expected Api {{ status: 500 }}, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn no_retry_on_404() {
+    let server = MockServer::start().await;
+
+    // 404 should not be retried — mock expects exactly one call.
+    Mock::given(method("GET"))
+        .and(path("/crates/nonexistent"))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = test_retry_client(&server.uri());
+    let err = client.get_crate("nonexistent").await.unwrap_err();
+
+    assert!(
+        matches!(err, super::Error::NotFound(_)),
+        "expected NotFound, got: {err:?}"
+    );
 }
 
 // ── publish ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `max_retries` (default 3) and `initial_backoff` (default 500ms) fields to `CratesIoClient`
- New private `send_with_retry` helper wraps HTTP calls in a retry loop: retries on 429 and 5xx with exponential backoff (500ms → 1s → 2s), logs each retry via `tracing::warn`
- Update `send`, `send_query`, and `send_auth` to use the helper; write operations (PUT/DELETE/PATCH/POST) are not retried
- Add `with_max_retries` and `with_initial_backoff` builder methods for configuration

Closes #42

## Test plan

- [ ] `retry_succeeds_after_transient_500` — first call 500, second succeeds
- [ ] `retry_succeeds_after_429` — first call 429, second succeeds
- [ ] `gives_up_after_max_retries` — all calls 500, surfaces `Error::Api { status: 500 }`
- [ ] `no_retry_on_404` — 404 is not retried (mock expects exactly 1 call)
- [ ] All 110 existing tests continue to pass (existing `test_client` now uses `max_retries: 0`)