### PR TITLE
feat: log client IP of sampled HTTP requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,7 @@ dependencies = [
 name = "cratesio-mcp"
 version = "0.1.4"
 dependencies = [
+ "axum",
  "chrono",
  "clap",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ path = "src/main.rs"
 [dependencies]
 # Core MCP
 tower-mcp = { version = "0.9.1", features = ["http", "testing"] }
+# HTTP server types, for the client-IP request-logging middleware on the HTTP transport
+axum = "0.8"
 
 # HTTP client for crates.io API
 reqwest = { version = "0.12", features = ["json", "gzip"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -460,9 +460,66 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                     .layer(builder.layer(McpTracingLayer::new()).into_inner())
             };
 
-            transport.serve(&addr).await?;
+            // Take over routing (instead of `transport.serve`) so we can add an
+            // HTTP-level middleware that logs the real client IP. The MCP-level
+            // `.layer()` stack above operates on parsed MCP requests and never
+            // sees `/health` or raw HTTP headers, so request-origin logging has
+            // to live out here, outside the MCP service.
+            let app = transport
+                .into_router()
+                .layer(axum::middleware::from_fn(log_http_request));
+
+            let listener = tokio::net::TcpListener::bind(&addr).await?;
+            tracing::info!("MCP HTTP transport listening on {}", addr);
+            axum::serve(listener, app).await?;
         }
     }
 
     Ok(())
+}
+
+/// Sample rate for HTTP request-origin logging: 1 of every N requests is logged
+/// at INFO. The `/health` endpoint is polled continuously by the platform and
+/// any uptime monitors, so logging every request would flood the logs; sampling
+/// keeps the volume bounded while still surfacing the source IP and User-Agent
+/// of any high-frequency caller.
+const HTTP_LOG_SAMPLE_RATE: u64 = 50;
+
+/// Axum middleware that logs the originating client of a sampled subset of HTTP
+/// requests. Behind Fly.io the TCP peer is the Fly proxy, so the real client
+/// address arrives in the `Fly-Client-IP` header (falling back to
+/// `X-Forwarded-For`). Used to identify high-volume callers (e.g. health-check
+/// pollers) that never reach the MCP-level tracing layer.
+async fn log_http_request(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    if COUNTER
+        .fetch_add(1, Ordering::Relaxed)
+        .is_multiple_of(HTTP_LOG_SAMPLE_RATE)
+    {
+        let headers = req.headers();
+        let client_ip = headers
+            .get("fly-client-ip")
+            .or_else(|| headers.get("x-forwarded-for"))
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("unknown");
+        let user_agent = headers
+            .get(axum::http::header::USER_AGENT)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("unknown");
+        tracing::info!(
+            client_ip,
+            user_agent,
+            method = %req.method(),
+            path = req.uri().path(),
+            sampled_1_in = HTTP_LOG_SAMPLE_RATE,
+            "HTTP request (sampled)"
+        );
+    }
+
+    next.run(req).await
 }


### PR DESCRIPTION
## Summary

Adds an axum HTTP-level middleware on the HTTP transport that logs the originating client of a sampled subset of requests, to identify high-frequency callers.

## Motivation

The live Fly.io deployment receives a steady ~9 requests/second (~518K/day) that is invisible in the app logs: the MCP-level `.layer()` stack (timeout, rate limiter, bulkhead, cache, tracing) operates on parsed MCP requests and never sees `/health` or raw HTTP headers. The volume is almost entirely `/health` polling from an unidentified source, and it keeps the machine awake 24/7. We have no way to tell *who* without logging the request origin.

## What it does

- Takes over routing via `HttpTransport::into_router()` + `axum::serve` instead of the `transport.serve()` convenience method (functionally identical bind/serve).
- Adds `log_http_request`, an `axum::middleware::from_fn` layer that logs, for 1 in every `HTTP_LOG_SAMPLE_RATE` (50) requests:
  - `client_ip` -- from the `Fly-Client-IP` header (Fly sets this; the TCP peer is the Fly proxy), falling back to `X-Forwarded-For`
  - `user_agent`, `method`, `path`

Sampling keeps log volume bounded (~one line every few seconds at current traffic) while still surfacing the source of any high-frequency caller. The first request always logs (counter starts at 0), so low-traffic origins are captured immediately too.

## Notes / follow-ups

- `axum = "0.8"` promoted from a transitive to a direct dependency (same version already in the tree).
- Once the poller is identified, a likely follow-up is rate-limiting `/health` -- which today bypasses the MCP-level `RateLimiterLayer` entirely (it wraps the MCP router, not the HTTP layer). Tracked separately.

## Testing

- `fmt`, `clippy -D warnings`, lib + integration tests all green.
- Manual smoke test: started the HTTP transport, hit `/health` with a simulated `Fly-Client-IP: 203.0.113.42` / `User-Agent: SmokeTest/1.0` -> got `200` and the expected log line:
  `HTTP request (sampled) client_ip="203.0.113.42" user_agent="SmokeTest/1.0" method=GET path="/health" sampled_1_in=50`