### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-06-11
+
+### Bug Fixes
+
+- Add #[serde(default)] to optional version params on 5 tools ([#99](https://github.com/joshrotenberg/cratesio-mcp/pull/99))
+- Bound rustdoc JSON response size from docs.rs ([#103](https://github.com/joshrotenberg/cratesio-mcp/pull/103))
+- Bound get_crate_readme response size ([#108](https://github.com/joshrotenberg/cratesio-mcp/pull/108))
+- Bound outbound HTTP calls with a per-request timeout (closes #88) ([#112](https://github.com/joshrotenberg/cratesio-mcp/pull/112))
+- Cap retry backoff with saturating math (closes #90) ([#115](https://github.com/joshrotenberg/cratesio-mcp/pull/115))
+- Cap unique crates in dependency tree to bound API calls (closes #92) ([#121](https://github.com/joshrotenberg/cratesio-mcp/pull/121))
+- Apply timeout/rate-limit/bulkhead middleware to stdio transport (closes #91) ([#123](https://github.com/joshrotenberg/cratesio-mcp/pull/123))
+
+### Documentation
+
+- Add readme field to Cargo.toml package metadata ([#100](https://github.com/joshrotenberg/cratesio-mcp/pull/100))
+- Add doc comments to CratesQueryBuilder methods and Sort variants ([#102](https://github.com/joshrotenberg/cratesio-mcp/pull/102))
+- Add example to format_number doc comment ([#107](https://github.com/joshrotenberg/cratesio-mcp/pull/107))
+- Sync README tool/prompt counts with registrations (closes #76) ([#110](https://github.com/joshrotenberg/cratesio-mcp/pull/110))
+
+### Features
+
+- Log client IP of sampled HTTP requests on the HTTP transport ([#94](https://github.com/joshrotenberg/cratesio-mcp/pull/94))
+- Add get_crate_changelog tool ([#72](https://github.com/joshrotenberg/cratesio-mcp/pull/72))
+- Add .icon() to authors, user, and user_stats tools ([#101](https://github.com/joshrotenberg/cratesio-mcp/pull/101))
+- Normalize MCP tool/prompt surface (closes #74, #77, #83) ([#124](https://github.com/joshrotenberg/cratesio-mcp/pull/124))
+- Add get_release_timeline tool (closes #55) ([#125](https://github.com/joshrotenberg/cratesio-mcp/pull/125))
+- Auto-reinitialize unknown MCP sessions to stop GET / churn ([#130](https://github.com/joshrotenberg/cratesio-mcp/pull/130))
+
+### Miscellaneous Tasks
+
+- Update rustls-webpki to 0.103.13 to fix RUSTSEC advisories ([#96](https://github.com/joshrotenberg/cratesio-mcp/pull/96))
+- Gate HTTP request-origin logging behind --log-requests (default off) ([#98](https://github.com/joshrotenberg/cratesio-mcp/pull/98))
+- Add roba.toml worker dispatch config ([#109](https://github.com/joshrotenberg/cratesio-mcp/pull/109))
+- Untrack accidentally-committed worker artifacts; gitignore .worktrees and .claudes ([#113](https://github.com/joshrotenberg/cratesio-mcp/pull/113))
+- Raise worker max_turns 40->80 and budget cap 2->10 (test-bed dial-in) ([#114](https://github.com/joshrotenberg/cratesio-mcp/pull/114))
+- Enforce single-instance Fly deployment (closes #93) ([#126](https://github.com/joshrotenberg/cratesio-mcp/pull/126))
+- Upgrade tower-mcp 0.9.1 -> 0.12.0 ([#127](https://github.com/joshrotenberg/cratesio-mcp/pull/127))
+- Deploy to Fly only on release tag, not every merge to main ([#129](https://github.com/joshrotenberg/cratesio-mcp/pull/129))
+
+### Testing
+
+- Extend docs/format.rs coverage for module listing and item detail ([#104](https://github.com/joshrotenberg/cratesio-mcp/pull/104))
+- Cover find_alternatives in integration router + 404 error path (closes #78) ([#111](https://github.com/joshrotenberg/cratesio-mcp/pull/111))
+- Cover composite-tool error and edge paths (closes #85) ([#116](https://github.com/joshrotenberg/cratesio-mcp/pull/116))
+- Inline tests for the four new prompts (closes #75) ([#117](https://github.com/joshrotenberg/cratesio-mcp/pull/117))
+- Cover 3 untested client endpoints (closes #86) ([#118](https://github.com/joshrotenberg/cratesio-mcp/pull/118))
+- Error/empty-path tests for 9 simple tools (part 1, refs #82) ([#119](https://github.com/joshrotenberg/cratesio-mcp/pull/119))
+- Error/empty-path tests for 9 simple tools (part 2, closes #82) ([#120](https://github.com/joshrotenberg/cratesio-mcp/pull/120))
+
+
+
 ## [0.1.4] - 2026-03-19
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "cratesio-mcp"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cratesio-mcp"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP server for querying crates.io - the Rust package registry"


### PR DESCRIPTION



## 🤖 New release

* `cratesio-mcp`: 0.1.4 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `cratesio-mcp` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant DocsRsError:ResponseTooLarge in /tmp/.tmpC3Wg2T/cratesio-mcp/src/client/docsrs.rs:27
  variant Error:ResponseTooLarge in /tmp/.tmpC3Wg2T/cratesio-mcp/src/client/error.rs:40
  variant Error:ResponseTooLarge in /tmp/.tmpC3Wg2T/cratesio-mcp/src/client/error.rs:40

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  cratesio_mcp::client::CratesIoClient::new takes 2 parameters in /tmp/.tmp1W99sO/cratesio-mcp/src/client/mod.rs:74, but now takes 3 parameters in /tmp/.tmpC3Wg2T/cratesio-mcp/src/client/mod.rs:81
  cratesio_mcp::client::CratesIoClient::with_base_url takes 3 parameters in /tmp/.tmp1W99sO/cratesio-mcp/src/client/mod.rs:79, but now takes 4 parameters in /tmp/.tmpC3Wg2T/cratesio-mcp/src/client/mod.rs:86
  cratesio_mcp::client::osv::OsvClient::new takes 1 parameters in /tmp/.tmp1W99sO/cratesio-mcp/src/client/osv.rs:114, but now takes 2 parameters in /tmp/.tmpC3Wg2T/cratesio-mcp/src/client/osv.rs:116
  cratesio_mcp::client::osv::OsvClient::with_base_url takes 2 parameters in /tmp/.tmp1W99sO/cratesio-mcp/src/client/osv.rs:119, but now takes 3 parameters in /tmp/.tmpC3Wg2T/cratesio-mcp/src/client/osv.rs:121
  cratesio_mcp::client::docsrs::DocsRsClient::new takes 1 parameters in /tmp/.tmp1W99sO/cratesio-mcp/src/client/docsrs.rs:66, but now takes 2 parameters in /tmp/.tmpC3Wg2T/cratesio-mcp/src/client/docsrs.rs:115
  cratesio_mcp::client::docsrs::DocsRsClient::with_base_url takes 2 parameters in /tmp/.tmp1W99sO/cratesio-mcp/src/client/docsrs.rs:71, but now takes 3 parameters in /tmp/.tmpC3Wg2T/cratesio-mcp/src/client/docsrs.rs:120
  cratesio_mcp::state::AppState::new takes 3 parameters in /tmp/.tmp1W99sO/cratesio-mcp/src/state.rs:42, but now takes 4 parameters in /tmp/.tmpC3Wg2T/cratesio-mcp/src/state.rs:43
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0] - 2026-06-11

### Bug Fixes

- Add #[serde(default)] to optional version params on 5 tools ([#99](https://github.com/joshrotenberg/cratesio-mcp/pull/99))
- Bound rustdoc JSON response size from docs.rs ([#103](https://github.com/joshrotenberg/cratesio-mcp/pull/103))
- Bound get_crate_readme response size ([#108](https://github.com/joshrotenberg/cratesio-mcp/pull/108))
- Bound outbound HTTP calls with a per-request timeout (closes #88) ([#112](https://github.com/joshrotenberg/cratesio-mcp/pull/112))
- Cap retry backoff with saturating math (closes #90) ([#115](https://github.com/joshrotenberg/cratesio-mcp/pull/115))
- Cap unique crates in dependency tree to bound API calls (closes #92) ([#121](https://github.com/joshrotenberg/cratesio-mcp/pull/121))
- Apply timeout/rate-limit/bulkhead middleware to stdio transport (closes #91) ([#123](https://github.com/joshrotenberg/cratesio-mcp/pull/123))

### Documentation

- Add readme field to Cargo.toml package metadata ([#100](https://github.com/joshrotenberg/cratesio-mcp/pull/100))
- Add doc comments to CratesQueryBuilder methods and Sort variants ([#102](https://github.com/joshrotenberg/cratesio-mcp/pull/102))
- Add example to format_number doc comment ([#107](https://github.com/joshrotenberg/cratesio-mcp/pull/107))
- Sync README tool/prompt counts with registrations (closes #76) ([#110](https://github.com/joshrotenberg/cratesio-mcp/pull/110))

### Features

- Log client IP of sampled HTTP requests on the HTTP transport ([#94](https://github.com/joshrotenberg/cratesio-mcp/pull/94))
- Add get_crate_changelog tool ([#72](https://github.com/joshrotenberg/cratesio-mcp/pull/72))
- Add .icon() to authors, user, and user_stats tools ([#101](https://github.com/joshrotenberg/cratesio-mcp/pull/101))
- Normalize MCP tool/prompt surface (closes #74, #77, #83) ([#124](https://github.com/joshrotenberg/cratesio-mcp/pull/124))
- Add get_release_timeline tool (closes #55) ([#125](https://github.com/joshrotenberg/cratesio-mcp/pull/125))
- Auto-reinitialize unknown MCP sessions to stop GET / churn ([#130](https://github.com/joshrotenberg/cratesio-mcp/pull/130))

### Miscellaneous Tasks

- Update rustls-webpki to 0.103.13 to fix RUSTSEC advisories ([#96](https://github.com/joshrotenberg/cratesio-mcp/pull/96))
- Gate HTTP request-origin logging behind --log-requests (default off) ([#98](https://github.com/joshrotenberg/cratesio-mcp/pull/98))
- Add roba.toml worker dispatch config ([#109](https://github.com/joshrotenberg/cratesio-mcp/pull/109))
- Untrack accidentally-committed worker artifacts; gitignore .worktrees and .claudes ([#113](https://github.com/joshrotenberg/cratesio-mcp/pull/113))
- Raise worker max_turns 40->80 and budget cap 2->10 (test-bed dial-in) ([#114](https://github.com/joshrotenberg/cratesio-mcp/pull/114))
- Enforce single-instance Fly deployment (closes #93) ([#126](https://github.com/joshrotenberg/cratesio-mcp/pull/126))
- Upgrade tower-mcp 0.9.1 -> 0.12.0 ([#127](https://github.com/joshrotenberg/cratesio-mcp/pull/127))
- Deploy to Fly only on release tag, not every merge to main ([#129](https://github.com/joshrotenberg/cratesio-mcp/pull/129))

### Testing

- Extend docs/format.rs coverage for module listing and item detail ([#104](https://github.com/joshrotenberg/cratesio-mcp/pull/104))
- Cover find_alternatives in integration router + 404 error path (closes #78) ([#111](https://github.com/joshrotenberg/cratesio-mcp/pull/111))
- Cover composite-tool error and edge paths (closes #85) ([#116](https://github.com/joshrotenberg/cratesio-mcp/pull/116))
- Inline tests for the four new prompts (closes #75) ([#117](https://github.com/joshrotenberg/cratesio-mcp/pull/117))
- Cover 3 untested client endpoints (closes #86) ([#118](https://github.com/joshrotenberg/cratesio-mcp/pull/118))
- Error/empty-path tests for 9 simple tools (part 1, refs #82) ([#119](https://github.com/joshrotenberg/cratesio-mcp/pull/119))
- Error/empty-path tests for 9 simple tools (part 2, closes #82) ([#120](https://github.com/joshrotenberg/cratesio-mcp/pull/120))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).