### PR TITLE
chore: update rustls-webpki to fix 4 RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Lockfile-only `cargo update -p rustls-webpki` (0.103.9 -> 0.103.13) to clear all four open RUSTSEC advisories flagged by `cargo audit`. All are transitive (pulled in via the TLS stack), no code changes.

## Advisories fixed

| Advisory | Title |
|----------|-------|
| reachable panic | Reachable panic in certificate revocation list parsing |
| name constraints (URI) | Name constraints for URI names were incorrectly accepted |
| name constraints (wildcard) | Name constraints accepted for certificates asserting a wildcard name |
| CRL authority | CRLs not considered authoritative by Distribution Point due to faulty matching logic |

## After

`cargo audit` reports **0 vulnerabilities**. Three warnings remain and are intentionally left:

- `rand 0.9.2` (unsound with a custom logger using `rand::rng()`) -- no fixed release available; not triggered by this code.
- `js-sys 0.3.88` / `wasm-bindgen 0.2.111` (yanked) -- pinned exactly by `wasm-bindgen-futures` via `reqwest 0.12`, so they cannot move without a `reqwest` major bump. Both are wasm-only and unused on the Linux server target. Will clear when `reqwest` is upgraded separately.

## Testing

`cargo build`, lib tests (113), and integration tests (39) all pass.