### PR TITLE
fix: add #[serde(default)] to optional version params on 5 tools

### DIFF
--- a/src/tools/audit.rs
+++ b/src/tools/audit.rs
@@ -18,6 +18,7 @@ pub struct AuditInput {
     /// Crate name to audit
     name: String,
     /// Version to audit (default: latest)
+    #[serde(default)]
     version: Option<String>,
     /// Include dev dependencies in audit
     #[serde(default)]
@@ -189,4 +190,14 @@ pub fn build(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn input_deserializes_without_version_key() {
+        let input: super::AuditInput =
+            serde_json::from_value(serde_json::json!({"name": "serde"})).unwrap();
+        assert!(input.version.is_none());
+    }
 }

--- a/src/tools/dependencies.rs
+++ b/src/tools/dependencies.rs
@@ -17,6 +17,7 @@ pub struct DependenciesInput {
     /// Crate name
     name: String,
     /// Version (default: latest)
+    #[serde(default)]
     version: Option<String>,
     /// Include dev dependencies
     #[serde(default)]
@@ -101,4 +102,14 @@ pub fn build(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn input_deserializes_without_version_key() {
+        let input: super::DependenciesInput =
+            serde_json::from_value(serde_json::json!({"name": "serde"})).unwrap();
+        assert!(input.version.is_none());
+    }
 }

--- a/src/tools/dependency_tree.rs
+++ b/src/tools/dependency_tree.rs
@@ -19,6 +19,7 @@ pub struct DependencyTreeInput {
     /// Crate name
     name: String,
     /// Version (default: latest)
+    #[serde(default)]
     version: Option<String>,
     /// Maximum depth to recurse (default: 3, max: 5)
     max_depth: Option<u32>,
@@ -665,5 +666,12 @@ mod tests {
         // Should show root and direct deps but not recurse further
         assert!(text.contains("Dependency Tree: my-crate v1.0.0"));
         assert!(text.contains("dep-a"));
+    }
+
+    #[test]
+    fn input_deserializes_without_version_key() {
+        let input: super::DependencyTreeInput =
+            serde_json::from_value(serde_json::json!({"name": "serde"})).unwrap();
+        assert!(input.version.is_none());
     }
 }

--- a/src/tools/features.rs
+++ b/src/tools/features.rs
@@ -17,6 +17,7 @@ pub struct FeaturesInput {
     /// Crate name (e.g. "serde", "tokio")
     name: String,
     /// Version string (e.g. "1.0.0"). Defaults to latest version.
+    #[serde(default)]
     version: Option<String>,
 }
 
@@ -102,4 +103,14 @@ pub fn build(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn input_deserializes_without_version_key() {
+        let input: super::FeaturesInput =
+            serde_json::from_value(serde_json::json!({"name": "serde"})).unwrap();
+        assert!(input.version.is_none());
+    }
 }

--- a/src/tools/health_check.rs
+++ b/src/tools/health_check.rs
@@ -18,6 +18,7 @@ pub struct HealthCheckInput {
     /// Crate name to evaluate
     name: String,
     /// Version to check (default: latest)
+    #[serde(default)]
     version: Option<String>,
 }
 
@@ -439,5 +440,12 @@ mod tests {
         assert!(text.contains("audit_dependencies"));
         // Stale crate
         assert!(text.contains("Stale") || text.contains("Aging"));
+    }
+
+    #[test]
+    fn input_deserializes_without_version_key() {
+        let input: super::HealthCheckInput =
+            serde_json::from_value(serde_json::json!({"name": "serde"})).unwrap();
+        assert!(input.version.is_none());
     }
 }


### PR DESCRIPTION
Closes #73.

## Summary

Five tools expose `version: Option<String>` without `#[serde(default)]`, so omitting the key entirely (the normal LLM-caller behavior) fails deserialization instead of defaulting to latest.

One-line fix in each input struct, mirroring `ReadmeInput` / `AuthorsInput` / `VersionDownloadsInput`:

| Input struct | File |
|---|---|
| `DependenciesInput` | `src/tools/dependencies.rs` |
| `AuditInput` | `src/tools/audit.rs` |
| `DependencyTreeInput` | `src/tools/dependency_tree.rs` |
| `HealthCheckInput` | `src/tools/health_check.rs` |
| `FeaturesInput` | `src/tools/features.rs` |

Plus one regression test per struct (`input_deserializes_without_version_key`): deserializing input JSON without the `version` key succeeds with `version == None`.

No handler logic changes.

## Status

- [x] Draft PR opened (work observable here)
- [x] Implementation (done locally instead of via roba)
- [x] fmt / clippy / tests green locally (131 lib + 39 integration tests pass)
- [x] CI green
- [x] Ready for review