### PR TITLE
feat: add .icon() to authors, user, and user_stats tools

### DIFF
--- a/src/tools/authors.rs
+++ b/src/tools/authors.rs
@@ -30,6 +30,7 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .icon("https://crates.io/assets/cargo.png")
         .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<AuthorsInput>| async move {

--- a/src/tools/user.rs
+++ b/src/tools/user.rs
@@ -24,6 +24,7 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .description("Get a crates.io user's profile information by their GitHub username.")
         .read_only()
         .idempotent()
+        .icon("https://crates.io/assets/cargo.png")
         .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UserInput>| async move {

--- a/src/tools/user_stats.rs
+++ b/src/tools/user_stats.rs
@@ -27,6 +27,7 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
+        .icon("https://crates.io/assets/cargo.png")
         .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<UserStatsInput>| async move {


### PR DESCRIPTION
Adds `.icon("https://crates.io/assets/cargo.png")` to the `get_crate_authors`, `get_user`, and `get_user_stats` tool builders so they are consistent with the rest of the crates.io tool family. The docs.rs-targeting tools (`get_crate_docs`, `get_doc_item`, `search_docs`) intentionally remain without an icon.

One-line addition to each of `src/tools/authors.rs`, `src/tools/user.rs`, and `src/tools/user_stats.rs`, placed after `.idempotent()` matching the surrounding sibling tools.

Validation: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --lib` (131 passed) all green.

Closes #80.