### PR TITLE
docs: add doc comments to CratesQueryBuilder methods and Sort variants

### DIFF
--- a/src/client/query.rs
+++ b/src/client/query.rs
@@ -3,11 +3,17 @@
 /// Sort order for crate search results.
 #[derive(Debug, Clone, Copy)]
 pub enum Sort {
+    /// Sort alphabetically by crate name.
     Alphabetical,
+    /// Sort by relevance to the search query.
     Relevance,
+    /// Sort by all-time download count.
     Downloads,
+    /// Sort by recent download count.
     RecentDownloads,
+    /// Sort by most recently updated.
     RecentUpdates,
+    /// Sort by most recently added.
     NewlyAdded,
 }
 
@@ -35,6 +41,17 @@ pub struct CratesQuery {
 
 impl CratesQuery {
     /// Create a new query builder.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use cratesio_mcp::client::{CratesQuery, Sort};
+    ///
+    /// let query = CratesQuery::builder()
+    ///     .search("tower")
+    ///     .sort(Sort::Downloads)
+    ///     .build();
+    /// ```
     pub fn builder() -> CratesQueryBuilder {
         CratesQueryBuilder {
             query: CratesQuery::default(),
@@ -48,26 +65,31 @@ pub struct CratesQueryBuilder {
 }
 
 impl CratesQueryBuilder {
+    /// Set the search term to filter crates by.
     pub fn search(mut self, search: &str) -> Self {
         self.query.search = Some(search.to_string());
         self
     }
 
+    /// Set the sort order for the results.
     pub fn sort(mut self, sort: Sort) -> Self {
         self.query.sort = Some(sort);
         self
     }
 
+    /// Set the page number to fetch (1-based).
     pub fn page(mut self, page: u64) -> Self {
         self.query.page = Some(page);
         self
     }
 
+    /// Set the number of results to return per page.
     pub fn per_page(mut self, per_page: u64) -> Self {
         self.query.per_page = Some(per_page);
         self
     }
 
+    /// Finalize the builder and produce a [`CratesQuery`].
     pub fn build(self) -> CratesQuery {
         self.query
     }


### PR DESCRIPTION
Documents the public library surface in `src/client/query.rs` per the project standard that all public APIs carry doc comments.

## Changes

- Adds one-line `///` doc comments to each `Sort` enum variant (Alphabetical, Relevance, Downloads, RecentDownloads, RecentUpdates, NewlyAdded).
- Adds one-line `///` doc comments to the `CratesQueryBuilder` methods (`search`, `sort`, `page`, `per_page`, `build`).
- Adds a `# Examples` block to `CratesQuery::builder()` mirroring the README library-usage snippet, verified as a doctest.

## Validation

- `cargo fmt --all` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --lib` (131 passed) and `cargo test --doc` (new builder doctest passes)

Scope was limited to `src/client/query.rs` only. The issue also mentions `format_number` in `src/state.rs`; that was intentionally left out of this PR to avoid colliding with parallel work and is noted as a follow-up.

Closes #81.