### PR TITLE
fix: bound get_crate_readme response size

### DIFF
--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -34,4 +34,8 @@ pub enum Error {
     /// JSON serialization error.
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
+
+    /// Response body exceeded the maximum allowed size.
+    #[error("response too large for {path}: {size} bytes exceeds limit of {limit}")]
+    ResponseTooLarge { path: String, size: u64, limit: u64 },
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -38,6 +38,10 @@ pub use error::Error;
 pub use query::{CratesQuery, CratesQueryBuilder, Sort};
 pub use types::*;
 
+/// Maximum size in bytes for a text resource read (e.g. README), to bound
+/// memory use from an oversized or malicious response.
+const MAX_TEXT_RESPONSE_BYTES: u64 = 5 * 1024 * 1024;
+
 // ── Auth ────────────────────────────────────────────────────────────────────
 
 /// Authentication credentials for the crates.io API.
@@ -252,10 +256,37 @@ impl CratesIoClient {
         Ok(resp.json().await?)
     }
 
-    /// GET a text resource (e.g. readme).
+    /// GET a text resource (e.g. readme), bounded to [`MAX_TEXT_RESPONSE_BYTES`]
+    /// so an oversized or malicious response cannot exhaust memory.
     pub(crate) async fn get_text(&self, path: &str) -> Result<String, Error> {
-        let resp = self.send(path).await?;
-        Ok(resp.text().await?)
+        let mut resp = self.send(path).await?;
+
+        // Reject early if the server declares an oversized body.
+        if let Some(len) = resp.content_length()
+            && len > MAX_TEXT_RESPONSE_BYTES
+        {
+            return Err(Error::ResponseTooLarge {
+                path: path.to_string(),
+                size: len,
+                limit: MAX_TEXT_RESPONSE_BYTES,
+            });
+        }
+
+        // Content-Length may be absent or understated, so cap the actual read.
+        let mut buf: Vec<u8> = Vec::new();
+        while let Some(chunk) = resp.chunk().await? {
+            let total = buf.len() as u64 + chunk.len() as u64;
+            if total > MAX_TEXT_RESPONSE_BYTES {
+                return Err(Error::ResponseTooLarge {
+                    path: path.to_string(),
+                    size: total,
+                    limit: MAX_TEXT_RESPONSE_BYTES,
+                });
+            }
+            buf.extend_from_slice(&chunk);
+        }
+
+        Ok(String::from_utf8_lossy(&buf).into_owned())
     }
 
     // ── Authenticated HTTP helpers ──────────────────────────────────────

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -564,6 +564,24 @@ async fn crate_readme_returns_text() {
     assert_eq!(readme, readme_text);
 }
 
+#[tokio::test]
+async fn crate_readme_rejects_oversized_response() {
+    let server = MockServer::start().await;
+    // Body larger than the 5 MiB get_text cap.
+    let big = "a".repeat(6 * 1024 * 1024);
+
+    Mock::given(method("GET"))
+        .and(path("/crates/huge/1.0.0/readme"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(big))
+        .mount(&server)
+        .await;
+
+    let client = test_client(&server.uri());
+    let err = client.crate_readme("huge", "1.0.0").await.unwrap_err();
+
+    assert!(matches!(err, super::Error::ResponseTooLarge { .. }));
+}
+
 // ── crate_reverse_dependencies ─────────────────────────────────────────────
 
 const REVERSE_DEPS_JSON: &str = r#"{


### PR DESCRIPTION
## Summary

`CratesIoClient::get_text` (the README fetch path, its only caller) read the body with an unbounded `resp.text().await?`, so a huge or malicious README response could exhaust memory -- the same class of issue fixed for rustdoc JSON in #89 / PR #103.

## Change

- Cap `get_text` at 5 MiB (`MAX_TEXT_RESPONSE_BYTES`):
  - reject early if `Content-Length` exceeds the limit;
  - because `Content-Length` may be absent or understated, also cap the actual read by accumulating `resp.chunk()` and bailing once the total passes the limit.
- Add a `ResponseTooLarge { path, size, limit }` variant to `client::Error`.
- Decode with `String::from_utf8_lossy` to keep `reqwest`'s lenient behavior.
- Add a wiremock test asserting an oversized README response yields `ResponseTooLarge`.

## Testing

`fmt`, `clippy -D warnings`, lib (132) + integration (39) tests, and `cargo doc` all pass.

Follow-up to #89 (flagged by that PR's implementer as an out-of-scope parallel gap).

Closes #105.