### PR TITLE
docs: sync README tool/prompt counts with registrations (closes #76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Add to `claude_desktop_config.json`:
 
 ## What's included
 
-### Tools (23)
+### Tools (28)
 
 | Tool | Description |
 |------|-------------|
@@ -117,6 +117,11 @@ Add to `claude_desktop_config.json`:
 | `get_category` | Details for a specific category |
 | `get_keywords` | Browse crates.io keywords |
 | `get_keyword` | Details for a specific keyword |
+| `compare_crates` | Compare two or more crates side by side (downloads, versions, dependencies, freshness) |
+| `get_dependency_tree` | Full transitive dependency tree with configurable depth and deduplication markers |
+| `crate_health_check` | Comprehensive health report (maturity, adoption, maintenance, security, dependency weight) |
+| `find_alternatives` | Find and compare alternative crates based on keywords, downloads, and recent activity |
+| `get_crate_changelog` | Changelog content from a crate's GitHub repository, optionally filtered to a version |
 
 ### Resources (4)
 
@@ -127,12 +132,16 @@ Add to `claude_desktop_config.json`:
 | `crates://{name}/docs` | Documentation structure |
 | Recent searches | Recent search queries and results |
 
-### Prompts (2)
+### Prompts (6)
 
 | Prompt | Description |
 |--------|-------------|
 | `analyze_crate` | Guided comprehensive crate analysis |
 | `compare_crates` | Compare multiple crates side by side |
+| `stack_review` | Evaluate a set of crates as a cohesive stack for compatibility and health |
+| `evaluate_dependencies` | Evaluate a project's dependencies for health, security, and maintenance |
+| `recommend_crates` | Find and evaluate crates for a given use case |
+| `migration_guide` | Generate a migration guide for switching between two crates |
 
 ## Transports
 


### PR DESCRIPTION
## Plan
Sync README's "What's included" section with the actual registrations in src/main.rs: the `Tools (N)` and `Prompts (N)` headings + tables are stale (missing 4 tools and 4 prompts). The worker verifies the real counts from the code (not the issue's numbers), updates headings, and adds a row per missing item with a description sourced from each tool/prompt definition. Closes #76.

Dispatched via roba (`--profile worker` -- sonnet, full-auto, from the committed roba.toml). Full prompt below.

<details><summary>Full dispatch prompt</summary>

# Sync README tool/prompt counts + tables with registrations (closes #76)

Authoritative: `gh issue view 76` -- read it. README.md's "What's included"
section is stale: the `### Tools (23)` heading + table omit 4 registered tools, and
`### Prompts (2)` omits 4 registered prompts. You are on branch `docs/readme-counts`.
Do NOT create a branch, push, open/modify a PR, or touch main -- only edit + commit.

## Task

1. **Verify the real counts FIRST** -- read `src/main.rs` and count the actually-
   registered tools and prompts. Do NOT trust the issue's numbers blindly; the README
   must match the CODE. (The issue says 27 tools / 6 prompts; confirm.)
2. Update `README.md`:
   - `### Tools (N)` heading to the real tool count; add a table row for each missing
     tool (`compare_crates`, `get_dependency_tree`, `crate_health_check`,
     `find_alternatives`) with an ACCURATE one-line description sourced from the
     tool's own definition/doc in `src/tools/*` -- do not invent descriptions.
   - `### Prompts (N)` heading to the real prompt count; add a row for each missing
     prompt (`stack_review`, `evaluate_dependencies`, `recommend_crates`,
     `migration_guide`), descriptions sourced from the prompt definitions.
   - Match the existing table's column format and row style exactly.
3. If you find the real counts differ from the issue's (e.g. a tool was added/removed
   since), use the CODE's truth and note the discrepancy in your summary.

## Gates (docs-only, but confirm nothing broke)

- `cargo fmt --all -- --check`
- `cargo build` (the change is README-only; just confirm the tree still builds)
- If the repo has a markdown linter configured (check `justfile`/`Makefile`/CI), run it.

## Steps

1. Read #76 + main.rs + the tool/prompt defs; verify counts; edit README.
2. `cargo fmt --all -- --check`
3. `cargo build` 2>&1 (clean)
4. If green: `git add README.md` then
   `git commit -m "docs: sync README tool/prompt counts and tables with registrations (closes #76)"`
5. Print `git log --oneline -1`, `git diff HEAD^ --stat`, and the verified counts.

## Constraints

- Stay on `docs/readme-counts`; NO push/PR/merge/main. README.md only (do not touch
  src). Sequential tool calls. If a count or description can't be sourced from the
  code, surface it -- don't guess.

</details>
