### PR TITLE
test: cover find_alternatives in integration router + 404 error path (closes #78)

### DIFF
--- a/src/tools/alternatives.rs
+++ b/src/tools/alternatives.rs
@@ -375,6 +375,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn find_alternatives_crate_not_found() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/nonexistent-crate"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"name": "nonexistent-crate"}))
+            .await;
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
     async fn find_alternatives_custom_max_results() {
         let server = MockServer::start().await;
 

--- a/tests/mcp_integration.rs
+++ b/tests/mcp_integration.rs
@@ -44,6 +44,7 @@ fn test_router(state: Arc<AppState>) -> McpRouter {
         .tool(tools::dependency_tree::build(state.clone()))
         .tool(tools::health_check::build(state.clone()))
         .tool(tools::changelog::build(state.clone()))
+        .tool(tools::alternatives::build(state.clone()))
         .resource(resources::recent_searches::build(state.clone()))
         .resource_template(resources::crate_info::build(state.clone()))
         .resource_template(resources::readme::build(state.clone()))
@@ -258,13 +259,13 @@ async fn mount_get_crate(server: &MockServer) {
 // ── Discovery tests ────────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn list_tools_returns_all_21() {
+async fn list_tools_returns_all_24() {
     let server = MockServer::start().await;
     let mut client = initialized_client(&server).await;
 
     let tools = client.list_tools().await;
 
-    assert_eq!(tools.len(), 23);
+    assert_eq!(tools.len(), 24);
     let names: Vec<&str> = tools
         .iter()
         .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
@@ -292,6 +293,7 @@ async fn list_tools_returns_all_21() {
     assert!(names.contains(&"get_dependency_tree"));
     assert!(names.contains(&"crate_health_check"));
     assert!(names.contains(&"get_crate_changelog"));
+    assert!(names.contains(&"find_alternatives"));
 }
 
 #[tokio::test]
@@ -1415,4 +1417,93 @@ async fn tool_crate_health_check() {
     assert!(text.contains("Dependency Weight"));
     assert!(text.contains("MIT OR Apache-2.0"));
     assert!(text.contains("None")); // no vulnerabilities
+}
+
+// ── Find alternatives tool test ────────────────────────────────────────────
+
+const GET_CRATE_AXUM_JSON: &str = r#"{
+    "crate": {
+        "name": "axum-mcp",
+        "updated_at": "2026-01-01T00:00:00.000000Z",
+        "keywords": ["ai", "mcp"],
+        "categories": ["asynchronous"],
+        "created_at": "2026-01-01T00:00:00.000000Z",
+        "downloads": 500,
+        "recent_downloads": 500,
+        "max_version": "0.1.0",
+        "max_stable_version": "0.1.0",
+        "description": "An MCP implementation using axum",
+        "homepage": null,
+        "documentation": null,
+        "repository": null
+    },
+    "versions": [
+        {
+            "num": "0.1.0",
+            "yanked": false,
+            "created_at": "2026-01-01T00:00:00.000000Z",
+            "downloads": 500,
+            "license": "MIT"
+        }
+    ]
+}"#;
+
+#[tokio::test]
+async fn tool_find_alternatives() {
+    let server = MockServer::start().await;
+
+    // Target crate (tower-mcp has keywords ["ai", "mcp"])
+    mount_get_crate(&server).await;
+
+    // Search for alternatives by keyword "ai mcp"
+    Mock::given(method("GET"))
+        .and(path("/crates"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "crates": [
+                {
+                    "name": "tower-mcp",
+                    "max_version": "0.6.0",
+                    "description": "Tower-native MCP implementation",
+                    "downloads": 1721,
+                    "recent_downloads": 1721,
+                    "created_at": "2026-01-28T16:29:05.281129Z",
+                    "updated_at": "2026-02-11T13:21:51.089324Z"
+                },
+                {
+                    "name": "axum-mcp",
+                    "max_version": "0.1.0",
+                    "description": "An MCP implementation using axum",
+                    "downloads": 500,
+                    "recent_downloads": 500,
+                    "created_at": "2026-01-01T00:00:00.000000Z",
+                    "updated_at": "2026-01-01T00:00:00.000000Z"
+                }
+            ],
+            "meta": { "total": 2 }
+        })))
+        .mount(&server)
+        .await;
+
+    // Alternative crate detail
+    Mock::given(method("GET"))
+        .and(path("/crates/axum-mcp"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(GET_CRATE_AXUM_JSON, "application/json"),
+        )
+        .mount(&server)
+        .await;
+
+    let mut client = initialized_client(&server).await;
+    let result = client
+        .call_tool(
+            "find_alternatives",
+            serde_json::json!({"name": "tower-mcp"}),
+        )
+        .await;
+
+    assert!(!result.is_error);
+    let text = result.all_text();
+    assert!(text.contains("Alternatives to `tower-mcp`"));
+    assert!(text.contains("axum-mcp"));
+    assert!(text.contains("*(target)*"));
 }


### PR DESCRIPTION
## Plan
Cover `find_alternatives` end to end: register it in the integration `test_router` (`tests/mcp_integration.rs`), fix the tool-count assertion, add an integration test that calls it through the MCP router, and extend the inline tests in `src/tools/alternatives.rs` with a crate-not-found (404) error path -- following the existing wiremock 404 patterns in health_check/dependency_tree. Asserts mechanics (call path, discoverability, error shape), not recommendation quality. Closes #78.

Dispatched via roba (`--profile worker` -- sonnet, full-auto). Full prompt below.

<details><summary>Full dispatch prompt</summary>

# Cover find_alternatives in the integration router + add a 404 error path (closes #78)

Authoritative: `gh issue view 78` -- read it; it carries exact files, line refs, and
patterns. `find_alternatives` is not registered in the integration test router and its
inline tests lack a crate-not-found path. You are on branch `test/find-alternatives`.
Do NOT create a branch, push, open/modify a PR, or touch main -- only edit + commit.

## Task (per the issue)

1. `tests/mcp_integration.rs`:
   - Add `tools::alternatives::build` to the `test_router` (the pattern is at
     ~lines 24-52 -- mirror how the other tools are registered).
   - Update the tool-count assertion in `list_tools_returns_all_21` to the real new
     count (and rename the test if the count in its name is now wrong -- your judgment;
     match repo convention).
   - Add at least one integration test (e.g. `tool_find_alternatives`) that calls
     `find_alternatives` through the MCP router and asserts the call path works.
2. `src/tools/alternatives.rs`:
   - Extend the existing `#[cfg(test)]` block (~line 197+) with a crate-not-found
     (mock returns 404 for the target crate) error-path test. Follow the 404-mock
     pattern in `src/tools/health_check.rs` and `src/tools/dependency_tree.rs` tests
     (wiremock).

Assert MECHANICS (the call path runs, the tool is discoverable, the error path
returns the expected error shape) -- not the semantic quality of any recommendation.

## Gates (all must pass -- this is a test PR)

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (lib + integration; the new tests must pass)

## Steps

1. Read #78 + the referenced patterns (test_router, the 404-mock tests, the existing
   alternatives tests); implement.
2-4. Run the three gates above.
5. If green: `git add -A` then
   `git commit -m "test: cover find_alternatives in integration router + 404 error path (closes #78)"`
6. Print `git log --oneline -1`, `git diff HEAD^ --stat`, judgment calls (esp. the
   tool-count + any test rename).

## Constraints

- Stay on `test/find-alternatives`; NO push/PR/merge/main. Edit only the two files
  named (+ no src behavior changes -- tests only). Sequential tool calls;
  verify-before-mutate. If the 404-mock pattern differs from what the issue describes,
  follow the CODE and note it.

</details>
