### PR TITLE
fix: cap retry backoff with saturating math (closes #90)

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -159,6 +159,18 @@ impl CratesIoClient {
         *last = Some(Instant::now());
     }
 
+    /// Compute the capped exponential backoff for a given attempt number.
+    ///
+    /// Uses saturating arithmetic to avoid overflow for large attempt values, and
+    /// clamps the result to 30 seconds so a misconfigured max_retries cannot
+    /// produce multi-hour sleeps.
+    fn backoff_for(&self, attempt: u32) -> Duration {
+        let raw_multiplier = 2u32.saturating_pow(attempt);
+        self.initial_backoff
+            .saturating_mul(raw_multiplier)
+            .min(Duration::from_secs(30))
+    }
+
     /// Execute an HTTP request with exponential backoff retry on 429 and 5xx responses.
     ///
     /// `make_request` is called once per attempt. Retries are only performed for
@@ -183,7 +195,7 @@ impl CratesIoClient {
                 status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error();
 
             if retryable && attempt < self.max_retries {
-                let backoff = self.initial_backoff * 2u32.pow(attempt);
+                let backoff = self.backoff_for(attempt);
                 tracing::warn!(
                     attempt = attempt + 1,
                     max_retries = self.max_retries,

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -8,6 +8,43 @@ use super::types::{
     CrateSettings, NewGitHubConfig, NewGitLabConfig, PublishMetadata, VersionSettings,
 };
 
+// ── backoff_for ──────────────────────────────────────────────────────────────
+
+#[test]
+fn backoff_for_small_attempts_are_uncapped() {
+    let client = CratesIoClient::with_base_url(
+        "test-agent",
+        Duration::from_millis(0),
+        Duration::from_secs(30),
+        "http://localhost",
+    )
+    .unwrap()
+    .with_initial_backoff(Duration::from_millis(500));
+
+    assert_eq!(client.backoff_for(0), Duration::from_millis(500)); // 500ms * 2^0 = 500ms
+    assert_eq!(client.backoff_for(1), Duration::from_millis(1000)); // 500ms * 2^1 = 1s
+    assert_eq!(client.backoff_for(2), Duration::from_millis(2000)); // 500ms * 2^2 = 2s
+}
+
+#[test]
+fn backoff_for_large_attempt_is_capped_at_30s() {
+    let client = CratesIoClient::with_base_url(
+        "test-agent",
+        Duration::from_millis(0),
+        Duration::from_secs(30),
+        "http://localhost",
+    )
+    .unwrap()
+    .with_initial_backoff(Duration::from_millis(500));
+
+    // attempt=40 would overflow u32 with plain pow; must not panic and must cap at 30s
+    assert_eq!(client.backoff_for(40), Duration::from_secs(30));
+    // attempt=32 would also overflow; also capped
+    assert_eq!(client.backoff_for(32), Duration::from_secs(30));
+    // attempt=19: 500ms * 2^19 = ~73 hours without cap; capped at 30s
+    assert_eq!(client.backoff_for(19), Duration::from_secs(30));
+}
+
 /// Create a client pointed at the mock server with no rate limiting and retries disabled.
 fn test_client(base_url: &str) -> CratesIoClient {
     CratesIoClient::with_base_url(


### PR DESCRIPTION
## Plan
Fix the retry backoff at `client/mod.rs:168`: `2u32.pow(attempt)` panics in debug for attempt>=32 and grows unbounded (73h at attempt 19). Replace with saturating math capped at 30s (`saturating_pow` + `saturating_mul` + `.min(30s)`) -- fixes both the overflow panic and the days-long sleep. A pure `backoff_for(attempt)` helper makes the cap a tested invariant. Closes #90.

Dispatched via roba (`--profile worker` -- sonnet, max_turns 80).

<details><summary>Full dispatch prompt</summary>

# Fix unbounded/overflowing retry backoff (closes #90)

Authoritative: `gh issue view 90` -- read it. The retry backoff at
`src/client/mod.rs:~168`:

    let backoff = self.initial_backoff * 2u32.pow(attempt);

`2u32.pow(attempt)` PANICS in debug for `attempt >= 32` (overflow) and grows without
bound (73 hours at attempt 19) even below that. You are on branch
`fix/retry-backoff`. Do NOT create a branch, push, open/modify a PR, or touch main --
only edit + commit.

## Fix

Replace the multiply with a saturating, CAPPED calculation (per the issue):

    let raw_multiplier = 2u32.saturating_pow(attempt);
    let backoff = self
        .initial_backoff
        .saturating_mul(raw_multiplier)
        .min(Duration::from_secs(30)); // never sleep more than 30s between attempts

Verify `Duration` is in scope (add the `use` if not). The saturating + `.min(30s)`
fixes BOTH the panic and the unbounded growth -- that is the primary, sufficient fix.
A bounds-guard in `with_max_retries` is OPTIONAL; add it only if trivially clean and
surface that you did. Keep the retry SEMANTICS otherwise identical (same attempt
sequence, same retry conditions).

## Tests

- Add a unit test asserting the backoff calc with a LARGE attempt (e.g. 40) does NOT
  panic and the result is capped at 30s. If the backoff is computed inline in a
  private method, factor a tiny pure `fn backoff_for(attempt) -> Duration` so it is
  unit-testable (preferred -- makes the cap a tested invariant), or test via the
  public path if cleaner. Also assert a small attempt (0,1,2) gives the expected
  un-capped values.

## Gates (all must pass -- check EXIT CODES explicitly)

- `cargo fmt --all` then `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

## Steps

1. Read #90 + the retry code; implement the saturating+capped calc + the test.
2-4. Run the three gates (fmt FIRST, then check).
5. If green: `git add -A` then
   `git commit -m "fix: cap retry backoff with saturating math, never overflow or sleep for hours (closes #90)"`
6. Print `git log --oneline -1`, `git diff HEAD^ --stat`, judgment calls.

## Constraints

- Stay on `fix/retry-backoff`; NO push/PR/merge/main. Sequential tool calls;
  verify-before-mutate. Run `cargo fmt --all` (apply) BEFORE the `--check` so you
  never leave unformatted code. This is a focused one-function fix; do not refactor
  beyond it.

</details>
