### PR TITLE
test: cover composite-tool error and edge paths (closes #85)

### DIFF
--- a/src/tools/audit.rs
+++ b/src/tools/audit.rs
@@ -194,6 +194,256 @@ pub fn build(state: Arc<AppState>) -> Tool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(crates_url: &str, osv_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                crates_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), crates_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url("test", Duration::from_secs(30), osv_url).unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn audit_vulnerability_found() {
+        let crates_server = MockServer::start().await;
+        let osv_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/vuln-crate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "crate": {
+                    "name": "vuln-crate",
+                    "max_version": "0.1.0",
+                    "description": "Vulnerable crate",
+                    "downloads": 100,
+                    "created_at": "2026-01-01T00:00:00.000000Z",
+                    "updated_at": "2026-01-01T00:00:00.000000Z"
+                },
+                "versions": [{"num": "0.1.0", "yanked": false, "created_at": "2026-01-01T00:00:00.000000Z", "downloads": 100}]
+            })))
+            .mount(&crates_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/vuln-crate/0.1.0/dependencies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependencies": []
+            })))
+            .mount(&crates_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "vulns": [
+                    {
+                        "id": "RUSTSEC-2024-0001",
+                        "summary": "Use-after-free in vuln-crate",
+                        "references": [{"type": "ADVISORY", "url": "https://rustsec.org/advisories/RUSTSEC-2024-0001.html"}]
+                    }
+                ]
+            })))
+            .mount(&osv_server)
+            .await;
+
+        let state = test_state(&crates_server.uri(), &osv_server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "vuln-crate"})).await;
+
+        let text = result.all_text();
+        assert!(!result.is_error);
+        assert!(
+            text.contains("RUSTSEC-2024-0001"),
+            "advisory ID should appear in output, got: {text}"
+        );
+        assert!(text.contains("Vulnerabilities Found"));
+    }
+
+    #[tokio::test]
+    async fn audit_include_dev_deps() {
+        let crates_server = MockServer::start().await;
+        let osv_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "crate": {
+                    "name": "my-crate",
+                    "max_version": "1.0.0",
+                    "description": "Test crate",
+                    "downloads": 100,
+                    "created_at": "2026-01-01T00:00:00.000000Z",
+                    "updated_at": "2026-01-01T00:00:00.000000Z"
+                },
+                "versions": [{"num": "1.0.0", "yanked": false, "created_at": "2026-01-01T00:00:00.000000Z", "downloads": 100}]
+            })))
+            .mount(&crates_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/1.0.0/dependencies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependencies": [
+                    {"crate_id": "normal-dep", "req": "^1", "kind": "normal", "optional": false, "version_id": 1},
+                    {"crate_id": "dev-dep", "req": "^1", "kind": "dev", "optional": false, "version_id": 2}
+                ]
+            })))
+            .mount(&crates_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "vulns": []
+            })))
+            .mount(&osv_server)
+            .await;
+
+        let state = test_state(&crates_server.uri(), &osv_server.uri());
+
+        // Default (include_dev=false): only normal dep counted
+        let tool = super::build(Arc::clone(&state));
+        let result = tool
+            .call(serde_json::json!({"name": "my-crate", "include_dev": false}))
+            .await;
+        assert!(
+            result.all_text().contains("Dependencies checked**: 1"),
+            "without include_dev only normal dep should be counted"
+        );
+
+        // include_dev=true: normal + dev dep both counted
+        let tool2 = super::build(state);
+        let result2 = tool2
+            .call(serde_json::json!({"name": "my-crate", "include_dev": true}))
+            .await;
+        assert!(
+            result2.all_text().contains("Dependencies checked**: 2"),
+            "with include_dev both deps should be counted"
+        );
+    }
+
+    #[tokio::test]
+    async fn audit_explicit_version_override() {
+        let crates_server = MockServer::start().await;
+        let osv_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "crate": {
+                    "name": "my-crate",
+                    "max_version": "2.0.0",
+                    "description": "Test crate",
+                    "downloads": 100,
+                    "created_at": "2026-01-01T00:00:00.000000Z",
+                    "updated_at": "2026-01-01T00:00:00.000000Z"
+                },
+                "versions": [
+                    {"num": "2.0.0", "yanked": false, "created_at": "2026-06-01T00:00:00.000000Z", "downloads": 50},
+                    {"num": "1.0.0", "yanked": false, "created_at": "2026-01-01T00:00:00.000000Z", "downloads": 50}
+                ]
+            })))
+            .mount(&crates_server)
+            .await;
+
+        // Only the 1.0.0 endpoint is mocked -- if the tool incorrectly used 2.0.0 it would 404
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/1.0.0/dependencies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependencies": []
+            })))
+            .mount(&crates_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/query"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "vulns": []
+            })))
+            .mount(&osv_server)
+            .await;
+
+        let state = test_state(&crates_server.uri(), &osv_server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"name": "my-crate", "version": "1.0.0"}))
+            .await;
+
+        let text = result.all_text();
+        assert!(!result.is_error);
+        assert!(
+            text.contains("my-crate v1.0.0"),
+            "audit header should use the overridden version 1.0.0, got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn audit_osv_error_surfaced() {
+        let crates_server = MockServer::start().await;
+        let osv_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "crate": {
+                    "name": "my-crate",
+                    "max_version": "1.0.0",
+                    "description": "Test crate",
+                    "downloads": 100,
+                    "created_at": "2026-01-01T00:00:00.000000Z",
+                    "updated_at": "2026-01-01T00:00:00.000000Z"
+                },
+                "versions": [{"num": "1.0.0", "yanked": false, "created_at": "2026-01-01T00:00:00.000000Z", "downloads": 100}]
+            })))
+            .mount(&crates_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/1.0.0/dependencies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependencies": []
+            })))
+            .mount(&crates_server)
+            .await;
+
+        // OSV returns a server error -- should surface as a tool error
+        Mock::given(method("POST"))
+            .and(path("/query"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&osv_server)
+            .await;
+
+        let state = test_state(&crates_server.uri(), &osv_server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "my-crate"})).await;
+
+        assert!(
+            result.is_error,
+            "OSV API error should surface as a tool error"
+        );
+    }
+
     #[test]
     fn input_deserializes_without_version_key() {
         let input: super::AuditInput =

--- a/src/tools/compare.rs
+++ b/src/tools/compare.rs
@@ -158,3 +158,137 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn compare_partial_failure() {
+        let server = MockServer::start().await;
+
+        // good-crate succeeds
+        Mock::given(method("GET"))
+            .and(path("/crates/good-crate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "crate": {
+                    "name": "good-crate",
+                    "max_version": "1.0.0",
+                    "description": "A good crate",
+                    "downloads": 10000,
+                    "created_at": "2026-01-01T00:00:00.000000Z",
+                    "updated_at": "2026-01-01T00:00:00.000000Z"
+                },
+                "versions": [{"num": "1.0.0", "yanked": false, "created_at": "2026-01-01T00:00:00.000000Z", "downloads": 10000}]
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/good-crate/1.0.0/dependencies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependencies": []
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/good-crate/1.0.0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "version": {
+                    "num": "1.0.0",
+                    "yanked": false,
+                    "created_at": "2026-01-01T00:00:00.000000Z",
+                    "downloads": 10000,
+                    "license": "MIT"
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/good-crate/reverse_dependencies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependencies": [],
+                "versions": [],
+                "meta": {"total": 5}
+            })))
+            .mount(&server)
+            .await;
+
+        // bad-crate returns 404 -- triggers the Err(e) row-formatting path
+        Mock::given(method("GET"))
+            .and(path("/crates/bad-crate"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/bad-crate/reverse_dependencies"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"crates": "good-crate, bad-crate"}))
+            .await;
+
+        let text = result.all_text();
+        assert!(!result.is_error);
+        assert!(
+            text.contains("error:"),
+            "bad-crate cells should contain 'error:' from Err(e) formatting path, got: {text}"
+        );
+        assert!(text.contains("good-crate"));
+    }
+
+    #[tokio::test]
+    async fn compare_too_many_crates() {
+        let server = MockServer::start().await;
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+
+        let result = tool
+            .call(serde_json::json!({"crates": "a, b, c, d, e, f"}))
+            .await;
+
+        let text = result.all_text();
+        assert!(!result.is_error);
+        assert!(text.contains("at most 5"));
+    }
+}

--- a/src/tools/dependency_tree.rs
+++ b/src/tools/dependency_tree.rs
@@ -674,6 +674,187 @@ mod tests {
         assert!(text.contains("dep-a"));
     }
 
+    #[tokio::test]
+    async fn dependency_tree_depth_limit() {
+        let server = MockServer::start().await;
+
+        // root → d1 → d2; d2 depends on d3 which must NOT be fetched when max_depth=2
+        Mock::given(method("GET"))
+            .and(path("/crates/root"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "crate": {
+                    "name": "root",
+                    "max_version": "1.0.0",
+                    "description": "Root",
+                    "downloads": 100,
+                    "created_at": "2026-01-01T00:00:00.000000Z",
+                    "updated_at": "2026-01-01T00:00:00.000000Z"
+                },
+                "versions": [{"num": "1.0.0", "yanked": false, "created_at": "2026-01-01T00:00:00.000000Z", "downloads": 100}]
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/root/1.0.0/dependencies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependencies": [
+                    {"crate_id": "d1", "req": "^1", "kind": "normal", "optional": false, "version_id": 1}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/d1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "crate": {
+                    "name": "d1",
+                    "max_version": "1.0.0",
+                    "description": "D1",
+                    "downloads": 50,
+                    "created_at": "2026-01-01T00:00:00.000000Z",
+                    "updated_at": "2026-01-01T00:00:00.000000Z"
+                },
+                "versions": [{"num": "1.0.0", "yanked": false, "created_at": "2026-01-01T00:00:00.000000Z", "downloads": 50}]
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/d1/1.0.0/dependencies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependencies": [
+                    {"crate_id": "d2", "req": "^1", "kind": "normal", "optional": false, "version_id": 2}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/d2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "crate": {
+                    "name": "d2",
+                    "max_version": "1.0.0",
+                    "description": "D2",
+                    "downloads": 30,
+                    "created_at": "2026-01-01T00:00:00.000000Z",
+                    "updated_at": "2026-01-01T00:00:00.000000Z"
+                },
+                "versions": [{"num": "1.0.0", "yanked": false, "created_at": "2026-01-01T00:00:00.000000Z", "downloads": 30}]
+            })))
+            .mount(&server)
+            .await;
+
+        // d2 declares d3 as a dep; BFS will store this in cache for d2 but must not
+        // then fetch d3 (d2 is popped at depth 2 >= max_depth)
+        Mock::given(method("GET"))
+            .and(path("/crates/d2/1.0.0/dependencies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependencies": [
+                    {"crate_id": "d3", "req": "^1", "kind": "normal", "optional": false, "version_id": 3}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        // d3 is intentionally NOT mocked -- the BFS must not request it
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"name": "root", "max_depth": 2}))
+            .await;
+
+        let text = result.all_text();
+        assert!(!result.is_error);
+        assert!(text.contains("d1"), "d1 should appear in tree");
+        assert!(text.contains("d2"), "d2 should appear in tree");
+        // d3 appears as an unexpanded leaf (not in cache) -- its subtree is not walked
+        assert!(text.contains("d3"), "d3 should appear as a leaf entry");
+    }
+
+    #[tokio::test]
+    async fn dependency_tree_not_found_transitive_dep() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "crate": {
+                    "name": "my-crate",
+                    "max_version": "1.0.0",
+                    "description": "Test",
+                    "downloads": 100,
+                    "created_at": "2026-01-01T00:00:00.000000Z",
+                    "updated_at": "2026-01-01T00:00:00.000000Z"
+                },
+                "versions": [{"num": "1.0.0", "yanked": false, "created_at": "2026-01-01T00:00:00.000000Z", "downloads": 100}]
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/1.0.0/dependencies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependencies": [
+                    {"crate_id": "dep-ok", "req": "^1", "kind": "normal", "optional": false, "version_id": 1},
+                    {"crate_id": "dep-missing", "req": "^2", "kind": "normal", "optional": false, "version_id": 2}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/dep-ok"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "crate": {
+                    "name": "dep-ok",
+                    "max_version": "1.0.0",
+                    "description": "OK dep",
+                    "downloads": 50,
+                    "created_at": "2026-01-01T00:00:00.000000Z",
+                    "updated_at": "2026-01-01T00:00:00.000000Z"
+                },
+                "versions": [{"num": "1.0.0", "yanked": false, "created_at": "2026-01-01T00:00:00.000000Z", "downloads": 50}]
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/dep-ok/1.0.0/dependencies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependencies": []
+            })))
+            .mount(&server)
+            .await;
+
+        // dep-missing returns 404 -- BFS skips it (Err(_) => continue) so it
+        // ends up absent from cache and rendered as a leaf by build_node
+        Mock::given(method("GET"))
+            .and(path("/crates/dep-missing"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "my-crate"})).await;
+
+        let text = result.all_text();
+        assert!(!result.is_error);
+        assert!(
+            text.contains("dep-ok"),
+            "resolved dep should appear in tree"
+        );
+        // dep-missing was skipped in BFS but still declared in root's dep list;
+        // build_node renders it as a leaf (not-in-cache path)
+        assert!(
+            text.contains("dep-missing"),
+            "not-found transitive dep should appear as a leaf in tree"
+        );
+    }
+
     #[test]
     fn input_deserializes_without_version_key() {
         let input: super::DependencyTreeInput =


### PR DESCRIPTION
## Plan
Add error/edge-path test coverage to the three composite tools: `compare.rs` (partial-failure when one crate 404s, >5 validation -- no inline tests today), `dependency_tree.rs` (depth-limit cutoff, 404 transitive dep), `audit.rs` (vuln found, include_dev, version override, OSV error -- no inline tests today). Follows the existing two-server/recursive wiremock patterns. Asserts mechanics (error shape, depth halt, advisory ID present), not analysis quality. Closes #85.

Dispatched via roba (`--profile worker` -- sonnet, max_turns 80).

<details><summary>Full dispatch prompt</summary>

# Composite-tool error-path tests (closes #85)

Authoritative: `gh issue view 85` -- read it; it lists the exact missing tests per
file and the patterns to follow. Add error/edge-path coverage to the three composite
tools. You are on branch `test/composite-error-paths`. Do NOT create a branch, push,
open/modify a PR, or touch main -- only edit + commit.

## Task (per the issue's "Desired state")

1. `src/tools/compare.rs` -- add a `#[cfg(test)] mod tests` (none today):
   - partial-failure: one crate 404s, others succeed -> assert that crate's cells
     contain `"error:"` (the `Err(e)` row-formatting path, ~line 116).
   - >5 crates validation.
2. `src/tools/dependency_tree.rs` -- extend the existing tests:
   - depth-limit cutoff: mock a deep tree, assert traversal halts at `max_depth` (5).
   - not-found transitive dep: a dep's crate lookup returns 404.
3. `src/tools/audit.rs` -- add a `#[cfg(test)] mod tests` (none today):
   - vulnerability found: mock OSV returning a vuln, assert the advisory ID appears.
   - `include_dev = true` includes a dev dep.
   - explicit version override.
   - OSV API error surfaced as a tool error.

## Patterns (reuse, do not reinvent)

- `src/tools/health_check.rs` tests -- the two-server (crates_server + osv_server) mock
  pattern needed for audit.
- `src/tools/dependency_tree.rs` -- the recursive mock pattern.
- `src/tools/alternatives.rs` -- composite multi-call test structure.

Assert MECHANICS (the error path returns the expected error/shape, traversal halts at
the depth, the advisory ID is present) -- never the semantic quality of any analysis.
Account for the client constructor signatures gaining a timeout arg (recent #88) --
follow how the EXISTING tests in these files construct clients now.

## Gates (all must pass -- check EXIT CODES explicitly)

- `cargo fmt --all` then `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

## Steps

1. Read #85 + the three target files + the three pattern files; implement.
2. `cargo fmt --all` (apply) then `cargo fmt --all -- --check`
3. `cargo clippy --all-targets --all-features -- -D warnings`
4. `cargo test --all-features`
5. If green: `git add -A` then
   `git commit -m "test: cover composite-tool error and edge paths (closes #85)"`
6. Print `git log --oneline -1`, `git diff HEAD^ --stat`, judgment calls.

## Constraints

- Stay on `test/composite-error-paths`; NO push/PR/merge/main. Tests only -- no
  behavior changes to the tools. Sequential tool calls; verify-before-mutate. Run
  `cargo fmt --all` BEFORE `--check`. If a mock pattern in the issue doesn't match the
  current code, follow the CODE and note it.

</details>
