### PR TITLE
test: inline tests for the four new prompts (closes #75)

### DIFF
--- a/src/prompts/evaluate_dependencies.rs
+++ b/src/prompts/evaluate_dependencies.rs
@@ -50,3 +50,40 @@ pub fn build() -> Prompt {
         })
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn required_args_appear_in_text() {
+        let prompt = build();
+        let mut args = HashMap::new();
+        args.insert("crates".to_string(), "serde, anyhow".to_string());
+        let result = prompt.get(args).await.unwrap();
+        let text = result.first_message_text().expect("expected message text");
+        assert!(text.contains("serde"));
+        assert!(text.contains("anyhow"));
+    }
+
+    #[tokio::test]
+    async fn optional_use_case_appears_in_text() {
+        let prompt = build();
+        let mut args = HashMap::new();
+        args.insert("crates".to_string(), "reqwest".to_string());
+        args.insert("use_case".to_string(), "production web service".to_string());
+        let result = prompt.get(args).await.unwrap();
+        let text = result.first_message_text().expect("expected message text");
+        assert!(text.contains("reqwest"));
+        assert!(text.contains("production web service"));
+    }
+
+    #[tokio::test]
+    async fn description_is_set() {
+        let prompt = build();
+        let mut args = HashMap::new();
+        args.insert("crates".to_string(), "serde".to_string());
+        let result = prompt.get(args).await.unwrap();
+        assert!(result.description.is_some());
+    }
+}

--- a/src/prompts/migration_guide.rs
+++ b/src/prompts/migration_guide.rs
@@ -61,3 +61,34 @@ pub fn build() -> Prompt {
         })
         .build()
 }
+
+// migration_guide has no optional arguments; tests 1 and 3 only.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn required_args_appear_in_text() {
+        let prompt = build();
+        let mut args = HashMap::new();
+        args.insert("from_crate".to_string(), "hyper".to_string());
+        args.insert("to_crate".to_string(), "reqwest".to_string());
+        let result = prompt.get(args).await.unwrap();
+        let text = result.first_message_text().expect("expected message text");
+        assert!(text.contains("hyper"));
+        assert!(text.contains("reqwest"));
+    }
+
+    #[tokio::test]
+    async fn description_is_set() {
+        let prompt = build();
+        let mut args = HashMap::new();
+        args.insert("from_crate".to_string(), "hyper".to_string());
+        args.insert("to_crate".to_string(), "reqwest".to_string());
+        let result = prompt.get(args).await.unwrap();
+        assert!(result.description.is_some());
+        let desc = result.description.unwrap();
+        assert!(desc.contains("hyper"));
+        assert!(desc.contains("reqwest"));
+    }
+}

--- a/src/prompts/recommend.rs
+++ b/src/prompts/recommend.rs
@@ -61,3 +61,41 @@ pub fn build() -> Prompt {
         })
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn required_args_appear_in_text() {
+        let prompt = build();
+        let mut args = HashMap::new();
+        args.insert("use_case".to_string(), "CLI argument parsing".to_string());
+        let result = prompt.get(args).await.unwrap();
+        let text = result.first_message_text().expect("expected message text");
+        assert!(text.contains("CLI argument parsing"));
+        assert!(text.contains('5'));
+    }
+
+    #[tokio::test]
+    async fn optional_max_results_appears_in_text() {
+        let prompt = build();
+        let mut args = HashMap::new();
+        args.insert("use_case".to_string(), "REST API".to_string());
+        args.insert("max_results".to_string(), "10".to_string());
+        let result = prompt.get(args).await.unwrap();
+        let text = result.first_message_text().expect("expected message text");
+        assert!(text.contains("REST API"));
+        assert!(text.contains("10"));
+    }
+
+    #[tokio::test]
+    async fn description_is_set() {
+        let prompt = build();
+        let mut args = HashMap::new();
+        args.insert("use_case".to_string(), "async HTTP client".to_string());
+        let result = prompt.get(args).await.unwrap();
+        assert!(result.description.is_some());
+        assert!(result.description.unwrap().contains("async HTTP client"));
+    }
+}

--- a/src/prompts/stack_review.rs
+++ b/src/prompts/stack_review.rs
@@ -58,3 +58,41 @@ pub fn build() -> Prompt {
         })
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn required_args_appear_in_text() {
+        let prompt = build();
+        let mut args = HashMap::new();
+        args.insert("crates".to_string(), "serde, tokio".to_string());
+        let result = prompt.get(args).await.unwrap();
+        let text = result.first_message_text().expect("expected message text");
+        assert!(text.contains("serde"));
+        assert!(text.contains("tokio"));
+    }
+
+    #[tokio::test]
+    async fn optional_use_case_appears_in_text() {
+        let prompt = build();
+        let mut args = HashMap::new();
+        args.insert("crates".to_string(), "axum, tower".to_string());
+        args.insert("use_case".to_string(), "async web service".to_string());
+        let result = prompt.get(args).await.unwrap();
+        let text = result.first_message_text().expect("expected message text");
+        assert!(text.contains("axum"));
+        assert!(text.contains("async web service"));
+    }
+
+    #[tokio::test]
+    async fn description_is_set() {
+        let prompt = build();
+        let mut args = HashMap::new();
+        args.insert("crates".to_string(), "serde".to_string());
+        let result = prompt.get(args).await.unwrap();
+        assert!(result.description.is_some());
+        assert!(result.description.unwrap().contains("serde"));
+    }
+}


### PR DESCRIPTION
## Plan
Inline tests for the 4 new prompts (stack_review, evaluate_dependencies, migration_guide, recommend) -- pure functions, so direct-handler unit tests asserting required-arg inclusion, optional-arg handling, and the description field. Closes #75.

<details><summary>Prompt</summary>

# Inline tests for the 4 new prompts (closes #75)

Authoritative: `gh issue view 75`. Four prompts have no tests:
`src/prompts/{stack_review,evaluate_dependencies,migration_guide,recommend}.rs`. They
are PURE functions (no I/O). You are on branch `test/prompt-coverage`. Do NOT create a
branch, push, open/modify a PR, or touch main -- only edit + commit.

## Task

Add a `#[cfg(test)] mod tests` to each of the four files. Per the issue, each prompt
gets at minimum:
1. a test asserting the rendered prompt text includes the REQUIRED argument values;
2. a test with an OPTIONAL argument supplied (where the prompt has one);
3. a test verifying the `description` field on `GetPromptResult` is set.

The handlers are pure -- prefer calling the handler closure directly (no mock server),
per the issue. Mirror the established pattern in `tests/mcp_integration.rs`
(~lines 1251-1295, `prompt_analyze_crate`/`prompt_compare_crates`) for shape, and read
each prompt file to see its exact args (required vs optional) -- do not assume; some
may have no optional arg (then skip test 2 for that one and note it).

Assert MECHANICS (the arg value appears in the text, the description is present) --
never the semantic quality of the prompt wording.

## Gates (check EXIT CODES explicitly)

- `cargo fmt --all` then `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

## Steps

1. Read #75 + the four prompt files (note each one's args) + the pattern; implement.
2-4. Run the three gates (fmt apply, then check).
5. If green: `git add -A` then
   `git commit -m "test: add inline tests for the four new prompts (closes #75)"`
6. Print `git log --oneline -1`, `git diff HEAD^ --stat`, judgment calls (esp. any
   prompt with no optional arg).

## Constraints

- Stay on `test/prompt-coverage`; NO push/PR/merge/main. Tests only. Sequential tool
  calls. Run `cargo fmt --all` BEFORE `--check`.

</details>
