### PR TITLE
test: cover 3 untested client endpoints (closes #86)

### DIFF
--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -222,6 +222,48 @@ async fn crate_owners_parses_response() {
     assert_eq!(owners[0].url, "https://github.com/joshrotenberg");
 }
 
+// ── crate_user_owners ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn crate_user_owners_parses_response() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/crates/tower-mcp/owner_user"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(OWNERS_JSON, "application/json"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = test_client(&server.uri());
+    let owners = client.crate_user_owners("tower-mcp").await.unwrap();
+
+    assert_eq!(owners.len(), 1);
+    assert_eq!(owners[0].login, "joshrotenberg");
+    assert_eq!(owners[0].name.as_deref(), Some("Josh Rotenberg"));
+    assert_eq!(owners[0].kind.as_deref(), Some("user"));
+}
+
+// ── crate_team_owners ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn crate_team_owners_parses_response() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/crates/tower-mcp/owner_team"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(OWNERS_JSON, "application/json"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = test_client(&server.uri());
+    let owners = client.crate_team_owners("tower-mcp").await.unwrap();
+
+    assert_eq!(owners.len(), 1);
+    assert_eq!(owners[0].login, "joshrotenberg");
+}
+
 // ── summary ────────────────────────────────────────────────────────────────
 
 const SUMMARY_JSON: &str = r#"{
@@ -1782,6 +1824,24 @@ async fn exchange_oidc_token_sends_post() {
     let token = client.exchange_oidc_token("my-jwt").await.unwrap();
 
     assert_eq!(token, "cio-publish-token-abc");
+}
+
+// ── revoke_trusted_token ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn revoke_trusted_token_sends_delete() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/trustpub/tokens/42"))
+        .and(header("Authorization", "test-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = test_client(&server.uri()).with_auth("test-token");
+    client.revoke_trusted_token(42).await.unwrap();
 }
 
 // ── retry ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Plan
Wiremock tests for 3 untested client endpoints (crate_user_owners, crate_team_owners, revoke_trusted_token) in src/client/tests.rs, mirroring the tested siblings. Closes #86.

<details><summary>Prompt</summary>

# Wiremock tests for 3 untested client endpoints (closes #86)

Authoritative: `gh issue view 86`. Three client methods in `src/client/` lack tests:
`crate_user_owners` (owners.rs:19), `crate_team_owners` (owners.rs:25),
`revoke_trusted_token` (trusted.rs:96). All are small single-HTTP-call delegators
following the same shape as already-tested siblings (`crate_owners`,
`delete_github_config`). You are on branch `test/client-endpoints`. Do NOT branch,
push, PR, merge, or touch main -- only edit + commit.

## Task

Add three `#[tokio::test]` cases to `src/client/tests.rs`:
- `crate_user_owners_parses_response` (GET `/crates/{name}/owner_user`)
- `crate_team_owners_parses_response` (GET `/crates/{name}/owner_team`)
- `revoke_trusted_token_sends_delete` (DELETE `/trustpub/tokens/{id}`)

Mirror the EXISTING tests for `crate_owners` and `delete_github_config` in the same
file for mock setup + client construction (note the client now takes a timeout arg,
#88 -- follow the existing tests). Assert mechanics: the request hits the right
method+path and the response parses / the delete succeeds.

## Gates (explicit exit checks)

- `cargo fmt --all` then `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

## Steps

1. Read #86 + the 3 methods + their tested siblings; implement.
2-4. Gates (fmt apply then check).
5. If green: `git add -A` then
   `git commit -m "test: cover crate_user_owners, crate_team_owners, revoke_trusted_token (closes #86)"`
6. Print `git log --oneline -1`, `git diff HEAD^ --stat`.

## Constraints
- Stay on `test/client-endpoints`; NO push/PR/merge/main. Tests only. fmt before check.

</details>
