### PR TITLE
test: error/empty-path tests for 9 simple tools (part 1, refs #82)

### DIFF
--- a/src/tools/authors.rs
+++ b/src/tools/authors.rs
@@ -68,3 +68,98 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn authors_crate_not_found() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/nonexistent"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "nonexistent"})).await;
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn authors_api_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "my-crate"})).await;
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn authors_empty() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/1.0.0/authors"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "meta": { "names": [] },
+                "users": []
+            })))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"name": "my-crate", "version": "1.0.0"}))
+            .await;
+
+        assert!(!result.is_error);
+        assert!(result.all_text().contains("No authors listed"));
+    }
+}

--- a/src/tools/categories.rs
+++ b/src/tools/categories.rs
@@ -67,3 +67,81 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    // No 404 case: /categories is a listing endpoint with no single-resource lookup.
+
+    #[tokio::test]
+    async fn categories_api_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/categories"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({})).await;
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn categories_empty() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/categories"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "categories": [],
+                "meta": { "total": 0 }
+            })))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({})).await;
+
+        assert!(!result.is_error);
+        assert!(result.all_text().contains("0 total"));
+    }
+}

--- a/src/tools/category.rs
+++ b/src/tools/category.rs
@@ -57,3 +57,79 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn category_not_found() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/categories/nonexistent-slug"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"slug": "nonexistent-slug"}))
+            .await;
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn category_api_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/categories/web-programming"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"slug": "web-programming"}))
+            .await;
+
+        assert!(result.is_error);
+    }
+}

--- a/src/tools/dependencies.rs
+++ b/src/tools/dependencies.rs
@@ -106,10 +106,116 @@ pub fn build(state: Arc<AppState>) -> Tool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
     #[test]
     fn input_deserializes_without_version_key() {
         let input: super::DependenciesInput =
             serde_json::from_value(serde_json::json!({"name": "serde"})).unwrap();
         assert!(input.version.is_none());
+    }
+
+    #[tokio::test]
+    async fn dependencies_crate_not_found() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/nonexistent"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "nonexistent"})).await;
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn dependencies_api_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "my-crate"})).await;
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn dependencies_empty() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "crate": {
+                    "name": "my-crate",
+                    "max_version": "1.0.0",
+                    "downloads": 0,
+                    "created_at": "2025-01-01T00:00:00.000000Z",
+                    "updated_at": "2025-01-01T00:00:00.000000Z"
+                },
+                "versions": [
+                    {"num": "1.0.0", "yanked": false, "created_at": "2025-01-01T00:00:00.000000Z", "downloads": 0}
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/1.0.0/dependencies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependencies": []
+            })))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "my-crate"})).await;
+
+        assert!(!result.is_error);
+        assert!(result.all_text().contains("Total: 0 dependencies"));
     }
 }

--- a/src/tools/downloads.rs
+++ b/src/tools/downloads.rs
@@ -74,3 +74,77 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    // No meaningful empty case: empty version_downloads just renders a 0-total header with no rows.
+
+    #[tokio::test]
+    async fn downloads_not_found() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/nonexistent/downloads"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "nonexistent"})).await;
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn downloads_api_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/downloads"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "my-crate"})).await;
+
+        assert!(result.is_error);
+    }
+}

--- a/src/tools/info.rs
+++ b/src/tools/info.rs
@@ -92,3 +92,75 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn info_not_found() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/nonexistent"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "nonexistent"})).await;
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn info_api_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "my-crate"})).await;
+
+        assert!(result.is_error);
+    }
+}

--- a/src/tools/keyword_detail.rs
+++ b/src/tools/keyword_detail.rs
@@ -49,3 +49,75 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn keyword_not_found() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/keywords/nonexistent"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"id": "nonexistent"})).await;
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn keyword_api_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/keywords/async"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"id": "async"})).await;
+
+        assert!(result.is_error);
+    }
+}

--- a/src/tools/keywords.rs
+++ b/src/tools/keywords.rs
@@ -66,3 +66,81 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    // No 404 case: /keywords is a listing endpoint with no single-resource lookup.
+
+    #[tokio::test]
+    async fn keywords_api_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/keywords"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({})).await;
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn keywords_empty() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/keywords"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "keywords": [],
+                "meta": { "total": 0 }
+            })))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({})).await;
+
+        assert!(!result.is_error);
+        assert!(result.all_text().contains("0 total"));
+    }
+}

--- a/src/tools/owners.rs
+++ b/src/tools/owners.rs
@@ -66,3 +66,77 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    // No meaningful empty case: every valid crate on crates.io has at least one owner.
+
+    #[tokio::test]
+    async fn owners_not_found() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/nonexistent/owners"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "nonexistent"})).await;
+
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn owners_api_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/owners"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "my-crate"})).await;
+
+        assert!(result.is_error);
+    }
+}


### PR DESCRIPTION
## Plan
Part 1/2 of #82: inline error/empty-path tests (404 not-found, 500 API error, empty-result where meaningful) for 9 simple single-endpoint tools (authors, categories, category, dependencies, downloads, info, keyword_detail, keywords, owners), via the established wiremock pattern. Refs #82 (part 2 covers the other 9).

<details><summary>Prompt</summary>

# Error/empty-path tests for simple tools -- part 1 of 2, refs #82

Authoritative: `gh issue view 82`. 18 simple single-endpoint tools have only
happy-path integration coverage and NO inline tests. This is **part 1 of 2, refs #82** -- cover
ONLY these 9 tool files (the other 9 are a separate PR):
authors, categories, category, dependencies, downloads, info, keyword_detail, keywords, owners
(i.e. `src/tools/<name>.rs` for each). You are on branch `test/simple-tool-paths-1`. Do NOT branch,
push, PR, merge, or touch main -- only edit + commit.

## Task

Add a `#[cfg(test)] mod tests` to each of the 9 files above, covering (per the issue):
- **crate/resource not found** (mock a 404 -> the tool surfaces `Error::NotFound` /
  an error result);
- **API error** (mock a 500 -> surfaced as a tool error);
- **empty results** WHERE IT APPLIES (e.g. search returns 0 crates, categories/keywords
  return an empty list) -- skip this case for tools where "empty" isn't meaningful, and
  note which.

Use the established wiremock pattern from the already-tested tools (e.g.
`src/tools/health_check.rs`, `alternatives.rs`) for the mock server + client
construction (the client takes a timeout arg now, #88 -- follow existing tests). Each
tool's exact request path: read the tool file. Assert MECHANICS (error surfaced, empty
handled) -- never analysis quality.

## Gates (explicit exit checks)

- `cargo fmt --all` then `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

## Steps

1. Read `gh issue view 82` + the 9 target files + a tested tool for the pattern.
2. Implement the test module per file (establish the pattern on the first, apply to the
   rest -- be efficient; these are mechanical and similar).
3-5. Gates (fmt apply then check; clippy; test).
6. If green: `git add -A` then `git commit -m "test: error/empty-path tests for 9 simple tools (part 1, refs #82)"`
7. Print `git log --oneline -1`, `git diff HEAD^ --stat`, judgment calls (esp. which
   tools had no meaningful empty case).

## Constraints
- Stay on `test/simple-tool-paths-1`; NO push/PR/merge/main. ONLY the 9 named files (+ tests). Tests
  only -- no tool behavior changes. fmt before check. Be efficient -- one pattern,
  applied 9 times.

</details>
