### PR TITLE
test: error/empty-path tests for 9 simple tools (part 2, closes #82)

### DIFF
--- a/src/tools/readme.rs
+++ b/src/tools/readme.rs
@@ -68,3 +68,92 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn readme_crate_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/no-such-crate"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"name": "no-such-crate"}))
+            .await;
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn readme_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/1.0.0/readme"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"name": "my-crate", "version": "1.0.0"}))
+            .await;
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn readme_empty() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/1.0.0/readme"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("   "))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"name": "my-crate", "version": "1.0.0"}))
+            .await;
+        assert!(result.all_text().contains("No README found"));
+    }
+}

--- a/src/tools/reverse_deps.rs
+++ b/src/tools/reverse_deps.rs
@@ -94,3 +94,92 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn reverse_deps_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/no-such-crate/reverse_dependencies"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"name": "no-such-crate"}))
+            .await;
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn reverse_deps_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/reverse_dependencies"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "my-crate"})).await;
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn reverse_deps_empty() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/reverse_dependencies"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "dependencies": [],
+                "versions": [],
+                "meta": {"total": 0}
+            })))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "my-crate"})).await;
+        assert!(result.all_text().contains("0 crates depend"));
+    }
+}

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -103,3 +103,78 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn search_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"query": "nonexistent-xyz"}))
+            .await;
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn search_empty_results() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "crates": [],
+                "meta": {"total": 0}
+            })))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"query": "zzz-no-match"}))
+            .await;
+        assert!(result.all_text().contains("Found 0 crates"));
+    }
+}

--- a/src/tools/summary.rs
+++ b/src/tools/summary.rs
@@ -79,3 +79,59 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    // summary is a global stats endpoint -- no 404/not-found case; empty lists
+    // are included in every response and are not a meaningful edge case to test.
+
+    #[tokio::test]
+    async fn summary_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/summary"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({})).await;
+        assert!(result.is_error);
+    }
+}

--- a/src/tools/user.rs
+++ b/src/tools/user.rs
@@ -53,3 +53,71 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn user_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/users/ghost"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"username": "ghost"})).await;
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn user_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/users/someuser"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"username": "someuser"})).await;
+        assert!(result.is_error);
+    }
+}

--- a/src/tools/user_stats.rs
+++ b/src/tools/user_stats.rs
@@ -59,3 +59,71 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn user_stats_user_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/users/ghost"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"username": "ghost"})).await;
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn user_stats_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/users/someuser"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"username": "someuser"})).await;
+        assert!(result.is_error);
+    }
+}

--- a/src/tools/version_detail.rs
+++ b/src/tools/version_detail.rs
@@ -60,3 +60,75 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn version_detail_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/9.9.9"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"name": "my-crate", "version": "9.9.9"}))
+            .await;
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn version_detail_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/1.0.0"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"name": "my-crate", "version": "1.0.0"}))
+            .await;
+        assert!(result.is_error);
+    }
+}

--- a/src/tools/version_downloads.rs
+++ b/src/tools/version_downloads.rs
@@ -90,3 +90,97 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn version_downloads_crate_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/no-such-crate"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        // no version specified, so tool must fetch crate first
+        let result = tool
+            .call(serde_json::json!({"name": "no-such-crate"}))
+            .await;
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn version_downloads_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/1.0.0/downloads"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"name": "my-crate", "version": "1.0.0"}))
+            .await;
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn version_downloads_empty() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate/1.0.0/downloads"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "version_downloads": []
+            })))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"name": "my-crate", "version": "1.0.0"}))
+            .await;
+        // no error and the header line is present; no Daily Downloads table
+        assert!(!result.is_error);
+        assert!(result.all_text().contains("Download Statistics"));
+    }
+}

--- a/src/tools/versions.rs
+++ b/src/tools/versions.rs
@@ -76,3 +76,106 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::RwLock;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::client::CratesIoClient;
+    use crate::client::docsrs::DocsRsClient;
+    use crate::client::osv::OsvClient;
+    use crate::docs::cache::DocsCache;
+    use crate::state::AppState;
+
+    fn test_state(base_url: &str) -> Arc<AppState> {
+        Arc::new(AppState {
+            client: CratesIoClient::with_base_url(
+                "test",
+                Duration::from_millis(0),
+                Duration::from_secs(30),
+                base_url,
+            )
+            .unwrap(),
+            docsrs_client: DocsRsClient::with_base_url("test", Duration::from_secs(30), base_url)
+                .unwrap(),
+            osv_client: OsvClient::with_base_url(
+                "test",
+                Duration::from_secs(30),
+                "http://localhost:1",
+            )
+            .unwrap(),
+            docs_cache: DocsCache::new(10, Duration::from_secs(3600)),
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    #[tokio::test]
+    async fn versions_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/no-such-crate"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool
+            .call(serde_json::json!({"name": "no-such-crate"}))
+            .await;
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn versions_api_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "my-crate"})).await;
+        assert!(result.is_error);
+    }
+
+    #[tokio::test]
+    async fn versions_empty_after_filter() {
+        // All versions are yanked; with include_yanked=false (default) the list is empty.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/my-crate"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "crate": {
+                    "name": "my-crate",
+                    "max_version": "0.1.0",
+                    "downloads": 0,
+                    "created_at": "2025-01-01T00:00:00.000000Z",
+                    "updated_at": "2025-01-01T00:00:00.000000Z"
+                },
+                "versions": [
+                    {
+                        "num": "0.1.0",
+                        "yanked": true,
+                        "created_at": "2025-01-01T00:00:00.000000Z",
+                        "downloads": 0
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let state = test_state(&server.uri());
+        let tool = super::build(state);
+        let result = tool.call(serde_json::json!({"name": "my-crate"})).await;
+        assert!(!result.is_error);
+        assert!(result.all_text().contains("Showing 0 versions"));
+    }
+}


### PR DESCRIPTION
## Plan
Part 2/2 of #82: inline error/empty-path tests for the other 9 simple tools (readme, reverse_deps, search, summary, user, user_stats, version_detail, version_downloads, versions). Closes #82.

<details><summary>Prompt</summary>

# Error/empty-path tests for simple tools -- part 2 of 2, closes #82

Authoritative: `gh issue view 82`. 18 simple single-endpoint tools have only
happy-path integration coverage and NO inline tests. This is **part 2 of 2, closes #82** -- cover
ONLY these 9 tool files (the other 9 are a separate PR):
readme, reverse_deps, search, summary, user, user_stats, version_detail, version_downloads, versions
(i.e. `src/tools/<name>.rs` for each). You are on branch `test/simple-tool-paths-2`. Do NOT branch,
push, PR, merge, or touch main -- only edit + commit.

## Task

Add a `#[cfg(test)] mod tests` to each of the 9 files above, covering (per the issue):
- **crate/resource not found** (mock a 404 -> the tool surfaces `Error::NotFound` /
  an error result);
- **API error** (mock a 500 -> surfaced as a tool error);
- **empty results** WHERE IT APPLIES (e.g. search returns 0 crates, categories/keywords
  return an empty list) -- skip this case for tools where "empty" isn't meaningful, and
  note which.

Use the established wiremock pattern from the already-tested tools (e.g.
`src/tools/health_check.rs`, `alternatives.rs`) for the mock server + client
construction (the client takes a timeout arg now, #88 -- follow existing tests). Each
tool's exact request path: read the tool file. Assert MECHANICS (error surfaced, empty
handled) -- never analysis quality.

## Gates (explicit exit checks)

- `cargo fmt --all` then `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

## Steps

1. Read `gh issue view 82` + the 9 target files + a tested tool for the pattern.
2. Implement the test module per file (establish the pattern on the first, apply to the
   rest -- be efficient; these are mechanical and similar).
3-5. Gates (fmt apply then check; clippy; test).
6. If green: `git add -A` then `git commit -m "test: error/empty-path tests for 9 simple tools (part 2, closes #82)"`
7. Print `git log --oneline -1`, `git diff HEAD^ --stat`, judgment calls (esp. which
   tools had no meaningful empty case).

## Constraints
- Stay on `test/simple-tool-paths-2`; NO push/PR/merge/main. ONLY the 9 named files (+ tests). Tests
  only -- no tool behavior changes. fmt before check. Be efficient -- one pattern,
  applied 9 times.

</details>
