### PR TITLE
fix: apply timeout/rate-limit/bulkhead middleware to stdio transport (closes #91)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ struct Args {
     #[arg(short, long, default_value = "3000")]
     port: u16,
 
-    /// Request timeout in seconds (for HTTP transport inbound requests)
+    /// Request timeout in seconds (inbound requests, all transports)
     #[arg(long, default_value = "30")]
     request_timeout_secs: u64,
 
@@ -379,10 +379,28 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
 
     match args.transport {
         Transport::Stdio => {
-            // For stdio, we serve directly without middleware since error handling
-            // is more complex (would need error type conversion).
             tracing::info!("Serving over stdio");
-            StdioTransport::new(router).run().await?;
+            let rate_limiter = RateLimiterLayer::builder()
+                .limit_for_period(10)
+                .refresh_period(Duration::from_secs(1))
+                .timeout_duration(Duration::from_millis(500))
+                .build();
+
+            let bulkhead = BulkheadLayer::builder()
+                .max_concurrent_calls(args.max_concurrent)
+                .max_wait_duration(Duration::from_millis(500))
+                .build();
+
+            let mut transport = StdioTransport::new(router).layer(
+                ServiceBuilder::new()
+                    .layer(TimeoutLayer::new(Duration::from_secs(
+                        args.request_timeout_secs,
+                    )))
+                    .layer(rate_limiter)
+                    .layer(bulkhead)
+                    .into_inner(),
+            );
+            transport.run().await?;
         }
         Transport::Http => {
             let addr = format!("{}:{}", args.host, args.port);


### PR DESCRIPTION
## Plan
Apply the HTTP transport's middleware stack (TimeoutLayer + RateLimiterLayer + BulkheadLayer) to the stdio transport, which currently runs bare -- a hung outbound call blocks the default-transport session indefinitely. Mirror the HTTP layer setup via ServiceBuilder, resolving the error-type conversion the stale comment cited. Closes #91.

<details><summary>Prompt</summary>

# Apply middleware to the stdio transport (closes #91)

Authoritative: `gh issue view 91`. The stdio transport (`src/main.rs:360-365`) runs
with NO middleware -- no timeout, rate limiter, or bulkhead -- while the HTTP path
wraps the router with `TimeoutLayer` + `RateLimiterLayer` + `BulkheadLayer`. Stdio is
the DEFAULT transport (Claude Desktop/Code), so a hung outbound call blocks the session
indefinitely. You are on branch `fix/stdio-middleware`. Do NOT branch, push, PR, merge,
or touch main -- only edit + commit.

## Task

Wrap the stdio router with the SAME middleware the HTTP transport uses, via a
`ServiceBuilder`, before passing it to `StdioTransport::new(...)`. Read exactly how the
HTTP arm builds its layer stack (the `Transport::Http` arm + the `TimeoutLayer`/
`RateLimiterLayer`/`BulkheadLayer` setup ~main.rs:436) and mirror it onto the stdio arm:
- **At minimum** the per-request `TimeoutLayer` (`Duration::from_secs(args.request_timeout_secs)`).
- Add the rate limiter + bulkhead too IF they apply cleanly to the stdio service.
- The existing comment claims stdio needs "error type conversion" -- resolve it
  (map the layer error into what `StdioTransport` expects; `StdioTransport` uses the
  same `Service` trait as HTTP, so this is a `.map_err` / error-into conversion, not a
  blocker). If a specific layer genuinely cannot apply to stdio, surface WHY in your
  summary and apply the ones that can (timeout is the must-have).
- Update/remove the now-stale "we serve directly without middleware" comment.

## Tests

A full middleware behavior test over stdio is awkward; do NOT force a flaky one. At
minimum ensure the build + existing tests pass with the new service wiring. If a small
test that the stdio service constructs with the layers is clean, add it; otherwise note
that the change is compile-and-existing-tests-gated and explain.

## Gates (explicit exit checks)

- `cargo fmt --all` then `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

## Steps

1. Read #91 + the HTTP arm's middleware setup + the stdio arm; mirror the stack.
2-4. Gates (fmt apply then check).
5. If green: `git add -A` then
   `git commit -m "fix: apply timeout/rate-limit/bulkhead middleware to stdio transport (closes #91)"`
6. Print `git log --oneline -1`, `git diff HEAD^ --stat`, judgment calls (esp. the
   error-conversion approach + any layer that didn't apply).

## Constraints
- Stay on `fix/stdio-middleware`; NO push/PR/merge/main. Mirror the HTTP stack -- don't
  invent new layers/config. Sequential tool calls. fmt before check.

</details>
