### PR TITLE
feat!: normalize MCP tool/prompt surface (closes #74, #77, #83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ Add to `claude_desktop_config.json`:
 | `get_keyword` | Details for a specific keyword |
 | `compare_crates` | Compare two or more crates side by side (downloads, versions, dependencies, freshness) |
 | `get_dependency_tree` | Full transitive dependency tree with configurable depth and deduplication markers |
-| `crate_health_check` | Comprehensive health report (maturity, adoption, maintenance, security, dependency weight) |
-| `find_alternatives` | Find and compare alternative crates based on keywords, downloads, and recent activity |
+| `get_crate_health` | Comprehensive health report (maturity, adoption, maintenance, security, dependency weight) |
+| `get_alternatives` | Find and compare alternative crates based on keywords, downloads, and recent activity |
 | `get_crate_changelog` | Changelog content from a crate's GitHub repository, optionally filtered to a version |
 
 ### Resources (4)
@@ -137,7 +137,7 @@ Add to `claude_desktop_config.json`:
 | Prompt | Description |
 |--------|-------------|
 | `analyze_crate` | Guided comprehensive crate analysis |
-| `compare_crates` | Compare multiple crates side by side |
+| `compare_crates_analysis` | Compare multiple crates side by side |
 | `stack_review` | Evaluate a set of crates as a cohesive stack for compatibility and health |
 | `evaluate_dependencies` | Evaluate a project's dependencies for health, security, and maintenance |
 | `recommend_crates` | Find and evaluate crates for a given use case |

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,8 +151,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     let user_stats_tool = tools::user_stats::build(state.clone());
     let compare_tool = tools::compare::build(state.clone());
     let dependency_tree_tool = tools::dependency_tree::build(state.clone());
-    let health_check_tool = tools::health_check::build(state.clone());
-    let find_alternatives_tool = tools::alternatives::build(state.clone());
+    let get_crate_health_tool = tools::health_check::build(state.clone());
+    let get_alternatives_tool = tools::alternatives::build(state.clone());
     let changelog_tool = tools::changelog::build(state.clone());
 
     // Create base router with tools (always registered)
@@ -184,8 +184,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
          - get_user_stats: Get download statistics for a crates.io user\n\
          - compare_crates: Compare two or more crates side by side\n\
          - get_dependency_tree: Get full transitive dependency tree for a crate\n\
-         - crate_health_check: Comprehensive health report for a crate\n\
-         - find_alternatives: Find and compare alternative crates for a given crate\n\
+         - get_crate_health: Comprehensive health report for a crate\n\
+         - get_alternatives: Find and compare alternative crates for a given crate\n\
          - get_crate_changelog: Fetch changelog from a crate's GitHub repository\n\n\
          (Running in minimal mode - resources, prompts, and completions disabled)"
     } else {
@@ -216,8 +216,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
          - get_user_stats: Get download statistics for a crates.io user\n\
          - compare_crates: Compare two or more crates side by side\n\
          - get_dependency_tree: Get full transitive dependency tree for a crate\n\
-         - crate_health_check: Comprehensive health report for a crate\n\
-         - find_alternatives: Find and compare alternative crates for a given crate\n\
+         - get_crate_health: Comprehensive health report for a crate\n\
+         - get_alternatives: Find and compare alternative crates for a given crate\n\
          - get_crate_changelog: Fetch changelog from a crate's GitHub repository\n\n\
          Resources:\n\
          - crates://{name}/info: Get crate info as a resource\n\
@@ -225,7 +225,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
          - crates://{name}/docs: Get documentation structure for a crate\n\n\
          Use the prompts for guided analysis:\n\
          - analyze_crate: Comprehensive crate analysis\n\
-         - compare_crates: Compare multiple crates\n\
+         - compare_crates_analysis: Compare multiple crates\n\
          - stack_review: Evaluate a set of crates as a cohesive stack\n\
          - evaluate_dependencies: Evaluate project dependencies for health and security\n\
          - recommend_crates: Find and evaluate crates for a use case\n\
@@ -260,8 +260,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .tool(user_stats_tool)
         .tool(compare_tool)
         .tool(dependency_tree_tool)
-        .tool(health_check_tool)
-        .tool(find_alternatives_tool)
+        .tool(get_crate_health_tool)
+        .tool(get_alternatives_tool)
         .tool(changelog_tool);
 
     // Add resources, prompts, and completions unless in minimal mode

--- a/src/prompts/compare.rs
+++ b/src/prompts/compare.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use tower_mcp::{GetPromptResult, Prompt, PromptBuilder, PromptMessage, PromptRole};
 
 pub fn build() -> Prompt {
-    PromptBuilder::new("compare_crates")
+    PromptBuilder::new("compare_crates_analysis")
         .description("Compare two or more crates for a specific use case")
         .required_arg("crates", "Comma-separated list of crate names to compare")
         .required_arg("use_case", "What you want to use these crates for")

--- a/src/prompts/evaluate_dependencies.rs
+++ b/src/prompts/evaluate_dependencies.rs
@@ -15,7 +15,7 @@ pub fn build() -> Prompt {
 
             let mut prompt = format!(
                 "Please evaluate the following Rust dependencies: {}\n\n\
-                 For each crate, run `crate_health_check` to gather comprehensive data, then assess:\n\n\
+                 For each crate, run `get_crate_health` to gather comprehensive data, then assess:\n\n\
                  1. **Staleness**: Flag crates with no recent releases or inactive maintenance\n\
                  2. **Security**: Identify any known vulnerabilities or audit concerns\n\
                  3. **Adoption**: Flag low-download or low-ecosystem-usage crates\n\

--- a/src/prompts/recommend.rs
+++ b/src/prompts/recommend.rs
@@ -29,7 +29,7 @@ pub fn build() -> Prompt {
                  (e.g. framework names, problem domain, key features needed)\n\n\
                  2. **Search for candidates**: Use search_crates with those keywords to find \
                  up to {} candidate crates\n\n\
-                 3. **Health check top results**: Run crate_health_check on the most promising \
+                 3. **Health check top results**: Run get_crate_health on the most promising \
                  candidates to get comprehensive quality data\n\n\
                  4. **Compare on key dimensions**:\n\
                  - Downloads (total and recent trends)\n\

--- a/src/prompts/stack_review.rs
+++ b/src/prompts/stack_review.rs
@@ -21,7 +21,7 @@ pub fn build() -> Prompt {
             let mut prompt = format!(
                 "Please evaluate the following Rust crates as a cohesive stack: {}\n\n\
                  Use the available tools to perform a thorough stack review:\n\n\
-                 1. **Health Check**: Run crate_health_check on each crate to assess individual health\n\
+                 1. **Health Check**: Run get_crate_health on each crate to assess individual health\n\
                  2. **Dependency Analysis**: Run get_dependencies on each crate to identify shared \
                  transitive dependencies and potential version conflicts\n\
                  3. **Overlap Detection**: Check for overlapping functionality across the stack \

--- a/src/tools/alternatives.rs
+++ b/src/tools/alternatives.rs
@@ -27,7 +27,7 @@ fn default_max_results() -> usize {
 }
 
 pub fn build(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("find_alternatives")
+    ToolBuilder::new("get_alternatives")
         .title("Find Alternatives")
         .description(
             "Find and compare alternative crates for a given crate. Uses the crate's keywords \

--- a/src/tools/compare.rs
+++ b/src/tools/compare.rs
@@ -14,8 +14,8 @@ use crate::state::{AppState, format_number};
 /// Input for comparing crates
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct CompareInput {
-    /// Comma-separated list of crate names to compare (2-5 crates)
-    crates: String,
+    /// List of crate names to compare (2-5 crates)
+    crates: Vec<String>,
 }
 
 pub fn build(state: Arc<AppState>) -> Tool {
@@ -31,7 +31,7 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<CompareInput>| async move {
-                let names: Vec<&str> = input.crates.split(',').map(|s| s.trim()).collect();
+                let names: Vec<&str> = input.crates.iter().map(|s| s.trim()).collect();
 
                 if names.len() < 2 {
                     return Ok(CallToolResult::text(
@@ -265,7 +265,7 @@ mod tests {
         let state = test_state(&server.uri());
         let tool = super::build(state);
         let result = tool
-            .call(serde_json::json!({"crates": "good-crate, bad-crate"}))
+            .call(serde_json::json!({"crates": ["good-crate", "bad-crate"]}))
             .await;
 
         let text = result.all_text();
@@ -284,7 +284,7 @@ mod tests {
         let tool = super::build(state);
 
         let result = tool
-            .call(serde_json::json!({"crates": "a, b, c, d, e, f"}))
+            .call(serde_json::json!({"crates": ["a", "b", "c", "d", "e", "f"]}))
             .await;
 
         let text = result.all_text();

--- a/src/tools/health_check.rs
+++ b/src/tools/health_check.rs
@@ -23,7 +23,7 @@ pub struct HealthCheckInput {
 }
 
 pub fn build(state: Arc<AppState>) -> Tool {
-    ToolBuilder::new("crate_health_check")
+    ToolBuilder::new("get_crate_health")
         .title("Crate Health Check")
         .description(
             "Comprehensive health check for a crate. Combines multiple API calls into a single \

--- a/tests/mcp_integration.rs
+++ b/tests/mcp_integration.rs
@@ -291,9 +291,9 @@ async fn list_tools_returns_all_24() {
     assert!(names.contains(&"get_user_stats"));
     assert!(names.contains(&"compare_crates"));
     assert!(names.contains(&"get_dependency_tree"));
-    assert!(names.contains(&"crate_health_check"));
+    assert!(names.contains(&"get_crate_health"));
     assert!(names.contains(&"get_crate_changelog"));
-    assert!(names.contains(&"find_alternatives"));
+    assert!(names.contains(&"get_alternatives"));
 }
 
 #[tokio::test]
@@ -344,7 +344,7 @@ async fn list_prompts_returns_both() {
         .filter_map(|p| p.get("name").and_then(|n| n.as_str()))
         .collect();
     assert!(names.contains(&"analyze_crate"));
-    assert!(names.contains(&"compare_crates"));
+    assert!(names.contains(&"compare_crates_analysis"));
 }
 
 // ── Tool tests ─────────────────────────────────────────────────────────────
@@ -895,7 +895,7 @@ async fn tool_compare_crates() {
 
     let mut client = initialized_client(&server).await;
     let result = client
-        .call_tool("compare_crates", json!({"crates": "tower-mcp, serde"}))
+        .call_tool("compare_crates", json!({"crates": ["tower-mcp", "serde"]}))
         .await;
 
     assert!(!result.is_error);
@@ -917,7 +917,7 @@ async fn tool_compare_crates_too_few() {
     let server = MockServer::start().await;
     let mut client = initialized_client(&server).await;
     let result = client
-        .call_tool("compare_crates", json!({"crates": "serde"}))
+        .call_tool("compare_crates", json!({"crates": ["serde"]}))
         .await;
 
     assert!(!result.is_error);
@@ -1283,14 +1283,14 @@ async fn prompt_analyze_crate_with_use_case() {
 }
 
 #[tokio::test]
-async fn prompt_compare_crates() {
+async fn prompt_compare_crates_analysis() {
     let server = MockServer::start().await;
     let mut client = initialized_client(&server).await;
 
     let mut args = HashMap::new();
     args.insert("crates".to_string(), "serde, bincode".to_string());
     args.insert("use_case".to_string(), "binary serialization".to_string());
-    let result = client.get_prompt("compare_crates", args).await;
+    let result = client.get_prompt("compare_crates_analysis", args).await;
 
     let text = result.first_message_text().expect("expected message text");
     assert!(text.contains("serde"));
@@ -1357,7 +1357,7 @@ async fn tool_get_dependency_tree() {
 // ── Health check tool test ─────────────────────────────────────────────
 
 #[tokio::test]
-async fn tool_crate_health_check() {
+async fn tool_get_crate_health() {
     let crates_server = MockServer::start().await;
     let docsrs_server = MockServer::start().await;
     let osv_server = MockServer::start().await;
@@ -1403,7 +1403,7 @@ async fn tool_crate_health_check() {
 
     let mut client = full_initialized_client(&crates_server, &docsrs_server, &osv_server).await;
     let result = client
-        .call_tool("crate_health_check", json!({"name": "tower-mcp"}))
+        .call_tool("get_crate_health", json!({"name": "tower-mcp"}))
         .await;
 
     assert!(!result.is_error);
@@ -1449,7 +1449,7 @@ const GET_CRATE_AXUM_JSON: &str = r#"{
 }"#;
 
 #[tokio::test]
-async fn tool_find_alternatives() {
+async fn tool_get_alternatives() {
     let server = MockServer::start().await;
 
     // Target crate (tower-mcp has keywords ["ai", "mcp"])
@@ -1495,10 +1495,7 @@ async fn tool_find_alternatives() {
 
     let mut client = initialized_client(&server).await;
     let result = client
-        .call_tool(
-            "find_alternatives",
-            serde_json::json!({"name": "tower-mcp"}),
-        )
+        .call_tool("get_alternatives", serde_json::json!({"name": "tower-mcp"}))
         .await;
 
     assert!(!result.is_error);


### PR DESCRIPTION
## Plan
Breaking MCP-surface normalization (approved): #83 compare_crates input comma-string -> Vec<String>; #74 rename the prompt compare_crates -> compare_crates_analysis (tool keeps its name); #77 rename off-convention tools crate_health_check -> get_crate_health, find_alternatives -> get_alternatives. Full rename cascade across registrations, instructions, tests, README. feat! -> version bump. Closes #74, #77, #83.

<details><summary>Prompt</summary>

# Breaking MCP-surface normalization: #74 + #77 + #83 (closes #74, closes #77, closes #83)

Authoritative: `gh issue view 74`, `77`, `83`. Three cohesive BREAKING changes to the
published MCP tool/prompt surface (breaking is approved -- a deliberate version bump).
You are on branch `feat/api-normalization`. Do NOT branch, push, PR, merge, or touch
main -- only edit + commit.

## The three changes

1. **#83 -- `compare_crates` input: comma-String -> `Vec<String>`** (`src/tools/compare.rs`):
   change `CompareInput.crates: String` to `Vec<String>`; drop the `.split(',')` in the
   handler (use the Vec directly, still trim/validate 2-5 entries); update the field doc
   + the tool's input-schema description. Update any test that passes the comma string
   (e.g. the #85 compare tests + integration `tool_compare_crates*`) to pass a JSON array.

2. **#74 -- rename the PROMPT (not the tool)** `compare_crates` -> `compare_crates_analysis`
   (`src/prompts/compare.rs` `PromptBuilder::new(...)`): the TOOL keeps `compare_crates`;
   only the PROMPT is renamed, to disambiguate. Update the `instructions` block in
   `src/main.rs` and any prompt test (`prompt_compare_crates` in mcp_integration.rs) that
   references the prompt name.

3. **#77 -- normalize two off-convention TOOL names**:
   - `crate_health_check` -> `get_crate_health` (`src/tools/health_check.rs` `ToolBuilder::new`)
   - `find_alternatives` -> `get_alternatives` (`src/tools/alternatives.rs` `ToolBuilder::new`)

## The rename cascade -- update EVERY reference (compiler catches code; these are NOT all code)

- `src/main.rs`: tool registrations + the `instructions` block text.
- `tests/mcp_integration.rs`: the tool-name assertions, the tool-count test, and any
  test named/asserting the old names (e.g. `find_alternatives` -> `get_alternatives`;
  the `list_tools_returns_all_*` name assertions).
- `README.md`: the Tools table rows that name `find_alternatives` / `crate_health_check`
  (we just synced this table -- keep it correct).
- Inline tests in the renamed tools' files if they reference the tool name in output
  assertions.
- Grep the whole repo for the old names (`crate_health_check`, `find_alternatives`, and
  the prompt `compare_crates` in the prompts/instructions context) to catch every site.

Assert MECHANICS; do not change tool BEHAVIOR (only names + the compare input type).

## Gates (explicit exit checks)

- `cargo fmt --all` then `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

## Steps

1. Read the 3 issues; grep for every reference to the old names; make all 3 changes +
   the full cascade.
2-4. Gates (fmt apply then check; clippy; test -- the renamed-name + new-input
   assertions must pass).
5. If green: `git add -A` then `git commit -m "feat!: normalize MCP tool/prompt surface -- Vec compare input, rename ambiguous prompt + off-convention tools (closes #74, #77, #83)"`
6. Print `git log --oneline -1`, `git diff HEAD^ --stat`, and a list of every file/site
   you changed (so the rename completeness is reviewable).

## Constraints
- Stay on `feat/api-normalization`; NO push/PR/merge/main. Use `feat!:` (breaking).
  Sequential tool calls; verify-before-mutate. fmt before check. The renames must be
  COMPLETE -- a missed reference in instructions/README isn't compiler-caught, so grep
  exhaustively.

</details>
