### PR TITLE
chore: enforce single-instance Fly deployment (closes #93)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,16 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to Fly.io
-        run: flyctl deploy --remote-only
+        run: flyctl deploy --remote-only --strategy immediate
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Reap stale machines
+        run: |
+          echo "Destroying any stopped/suspended machines left from the deploy..."
+          flyctl machines list --json | jq -r '.[] | select(.state != "started") | .id' | xargs -I{} flyctl machines destroy {} --force || true
+          echo "Active machines after reap:"
+          flyctl machines list
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/fly.toml
+++ b/fly.toml
@@ -11,14 +11,15 @@ primary_region = "sjc"
   internal_port = 3000
   force_https = true
   auto_stop_machines = "suspend"
-  auto_start_machines = true
-  # MCP HTTP sessions are stored in-memory, so we need exactly 1 instance
+  auto_start_machines = false
+  # Single-instance is the deliberate design for this demo/reference deployment.
+  # MCP sessions are in-memory; scale-out would require a shared session store (see #93).
   min_machines_running = 1
   processes = ["app"]
   [http_service.concurrency]
     type = "requests"
-    hard_limit = 100
-    soft_limit = 80
+    hard_limit = 35
+    soft_limit = 25
 
 [[vm]]
   memory = "256mb"


### PR DESCRIPTION
## Plan
Option 3 (demo deployment): enforce single-instance -- fly.toml auto_start_machines=false + right-sized concurrency + a corrected comment, and a deploy-time stale-machine reap so two never coexist. No Redis/sticky routing (that's the not-chosen option 1). Closes #93.

<details><summary>Prompt</summary>

# Enforce single-instance (option 3) for the Fly deployment (closes #93)

Authoritative: `gh issue view 93`. Decision made: this is a demo/reference deployment,
NOT a scale-out target -> **option 3** (document + enforce single-instance; do NOT add
Redis/sticky routing). You are on branch `chore/fly-single-instance`. Do NOT branch,
push, PR, merge, or touch main -- only edit + commit.

## Task (option 3, per the issue)

1. `fly.toml`:
   - Set `auto_start_machines = false` (so Fly never starts a SECOND machine -- the
     in-memory session store can't tolerate two).
   - Keep `min_machines_running = 1`.
   - Right-size the `[http_service.concurrency]` limits to a single-machine budget (the
     current soft_limit=80/hard_limit=100 are what would trip a second-machine start;
     with auto_start off they won't, but set them to honest single-instance values --
     your judgment, e.g. a soft limit comfortably under the hard, sized for one 256mb
     machine).
   - Update the stale comment: it currently says "we need exactly 1 instance" as an
     apology; reword to state single-instance is the DELIBERATE design for this
     demo/reference deployment (sessions are in-memory; scale-out would need a shared
     store, tracked in #93).
2. **Reap stale machines on deploy** so two never coexist (the issue observed a deploy
   leaving an old machine alongside the new). READ the deploy workflow
   (`.github/workflows/deploy.yml`) and add the right mechanism -- e.g. `fly deploy`
   with an immediate/rolling strategy that replaces in place, or an explicit
   `fly machines list` + destroy-stale step after deploy. Use what fits the existing
   deploy setup; explain what you chose.

## Gates

- No Rust changes expected; confirm `cargo build` still works (trivially) if you touched
  anything compiled. The real artifacts are `fly.toml` + the deploy workflow.
- If a CI lint covers yaml/toml, run it.

## Steps

1. Read #93 + fly.toml + .github/workflows/deploy.yml; apply option 3.
2. `cargo build` (sanity -- should be unaffected).
3. If green: `git add -A` then `git commit -m "chore: enforce single-instance Fly deployment for the demo endpoint (closes #93)"`
4. Print `git log --oneline -1`, `git diff HEAD^ --stat`, and explain the stale-machine-reap mechanism you chose.

## Constraints
- Stay on `chore/fly-single-instance`; NO push/PR/merge/main. Option 3 only -- do NOT
  add Redis/sticky-routing (that's option 1, explicitly NOT chosen). fly.toml + deploy
  workflow only. Sequential tool calls.

</details>
