### PR TITLE
chore: upgrade tower-mcp 0.9.1 -> 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,9 +1999,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-mcp"
-version = "0.9.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d2680ddb4e9e26260e5c37ed7ba5eb93030a9fc57428c004b0b15904c89b4b"
+checksum = "96dd7df8b3c0f729ce9f294059f501fd8b1c53760bf61079c1433380fe66d76b"
 dependencies = [
  "async-trait",
  "axum",
@@ -2015,6 +2015,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tower",
@@ -2026,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "tower-mcp-types"
-version = "0.9.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f104da876114dc20c32cd82b3dabeaead05e449d02fb0945e5177fb96639ea"
+checksum = "6511f1f32c7cb7fd4525edc0eb4dcf307db8f7eceb2833ab24a37b4cc10cda61"
 dependencies = [
  "base64",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core MCP
-tower-mcp = { version = "0.9.1", features = ["http", "testing"] }
+tower-mcp = { version = "0.12", features = ["http", "testing"] }
 # HTTP server types, for the client-IP request-logging middleware on the HTTP transport
 axum = "0.8"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -482,14 +482,14 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 .layer(rate_limiter)
                 .layer(bulkhead);
 
-            // Conditionally add cache layer
-            // optional_sessions() allows clients that don't carry mcp-session-id
-            // forward (e.g. Codex CLI, Cursor) to still call tools.
+            // Conditionally add cache layer.
+            // Optional sessions (clients that don't carry mcp-session-id, e.g.
+            // Codex CLI, Cursor, can still call tools) are the default in
+            // tower-mcp 0.10+; use require_sessions() to opt into strict mode.
             // See: https://github.com/joshrotenberg/cratesio-mcp/issues/61
             let transport = if args.cache_enabled {
                 HttpTransport::new(router)
                     .disable_origin_validation()
-                    .optional_sessions()
                     .layer(
                         builder
                             .layer(cache)
@@ -499,7 +499,6 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             } else {
                 HttpTransport::new(router)
                     .disable_origin_validation()
-                    .optional_sessions()
                     .layer(builder.layer(McpTracingLayer::new()).into_inner())
             };
 


### PR DESCRIPTION
## Summary

Upgrades the core `tower-mcp` dependency three minor versions (0.9.1 -> 0.12.0) to keep this crate -- one of the larger tower-mcp consumers -- on the current release and surface any integration issues early.

## Breaking change encountered

Exactly one, and it was trivial:

- `HttpTransport::optional_sessions()` was **removed** because optional sessions became the **default** for the HTTP transport in 0.10 ([tower-mcp#761]). Dropped both call sites; behavior is unchanged (this is precisely what #61 wanted). `require_sessions()` is now the opt-in for strict mode. Updated the explanatory comment accordingly.

Nothing else in our surface (router/tool builders, `McpTracingLayer`, `into_router`, `disable_origin_validation`, the `testing`-feature `TestClient`, `RouterRequest`/`RouterResponse` middleware types) needed changes.

## Verification (all on 0.12.0)

- `cargo build`, `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- `cargo test --lib` -- 212 passed
- `cargo test --test '*'` (integration, TestClient) -- 40 passed
- `cargo test --doc` -- 2 passed
- Live HTTP round-trip: `initialize` -> `tools/list` returns 29 tools -> `GET /` holds the SSE stream open

## Notable opportunity (follow-up, not in this PR)

0.10.1 added **pluggable `SessionStore`** and **`auto_reinitialize_sessions()`** (restore/auto-reinit unknown sessions instead of erroring `-32005`). Both are directly relevant to the open work:

- `session_store(Arc<dyn SessionStore>)` is the fix path for #93 (in-memory sessions block horizontal scaling).
- `auto_reinitialize_sessions(true)` would let clients with a stale session (e.g. after a deploy wipes the in-memory store) recover transparently instead of reconnecting -- directly addressing the #97 `GET /` churn.

Both are behavior changes worth a deliberate follow-up rather than bundling into a dependency bump.

[tower-mcp#761]: https://github.com/joshrotenberg/tower-mcp/pull/761