### PR TITLE
ci: deploy to Fly only on release tag, not every merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,14 @@
 name: Deploy to Fly.io
 
 on:
+  # Deploy only when a release is cut: release-plz pushes a v{MAJOR}.{MINOR}.{PATCH}
+  # tag (git_tag_enable in release-plz.toml), which is the same signal cargo-dist's
+  # release.yml uses. This keeps the live server on the latest released version and
+  # avoids bouncing the machine (and wiping in-memory MCP sessions, see #93/#97) on
+  # every merge to main. Use the manual workflow_dispatch run for hotfix deploys.
   push:
-    branches:
-      - main
-    paths:
-      - 'src/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'Dockerfile'
-      - 'fly.toml'
-      - '.github/workflows/deploy.yml'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Changes `.github/workflows/deploy.yml` to deploy **only when a release is cut** (a `v{MAJOR}.{MINOR}.{PATCH}` tag) instead of on every push to `main`.

```diff
 on:
-  push:
-    branches: [main]
-    paths: ['src/**', 'Cargo.toml', 'Cargo.lock', 'Dockerfile', 'fly.toml', '.github/workflows/deploy.yml']
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
```

## Why

Every merged PR was redeploying the live server. Because MCP HTTP sessions are stored in process memory (#93), each deploy bounces the machine and wipes all sessions, causing a reconnect storm for live Claude Code / Copilot users (the `GET /` churn in #97). Deploying once per release -- a deliberate event -- eliminates the churn from in-progress merges while keeping the live server on the latest released version.

## How it fits the existing release flow

- `release-plz.toml` has `git_tag_enable = true` (and `git_release_enable = false`), so release-plz pushes a `vX.Y.Z` tag on each release. cargo-dist's `release.yml` already fires on that same tag, so this just adds the deploy to the same trigger.
- release-plz pushes tags with `COMMITTER_TOKEN`, so tag-based workflows (this one, and `release.yml`) are triggered as expected.
- Stable releases only; prerelease tags are intentionally excluded.
- `workflow_dispatch` is retained for manual / hotfix deploys between releases.

## Ordering note

A tag push runs the workflow file **as it exists at the tagged commit**. So this change governs a release's deploy only once it is merged to `main` *before* that release's tag is cut. Merge this ahead of the next release (e.g. before #95 / v0.2.0) for it to take effect on that release.

## Testing

CI config change; validated the YAML parses and the trigger block is well-formed. The deploy/health-check/MCP-verification steps are unchanged. Real validation is the next release cutting a single deploy (and merges to `main` no longer deploying).

Closes #128.