### PR TITLE
feat: auto-reinitialize unknown MCP sessions to stop GET / churn

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -487,9 +487,17 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             // Codex CLI, Cursor, can still call tools) are the default in
             // tower-mcp 0.10+; use require_sessions() to opt into strict mode.
             // See: https://github.com/joshrotenberg/cratesio-mcp/issues/61
+            //
+            // auto_reinitialize_sessions: when a client presents an unknown
+            // session id (e.g. after a deploy/restart wipes the in-memory store),
+            // the server transparently re-initializes it instead of returning
+            // -32005, so the client continues without a reconnect storm. This is
+            // the standalone mitigation for the GET / churn in #97 (no external
+            // SessionStore required for our single-instance deployment).
             let transport = if args.cache_enabled {
                 HttpTransport::new(router)
                     .disable_origin_validation()
+                    .auto_reinitialize_sessions(true)
                     .layer(
                         builder
                             .layer(cache)
@@ -499,6 +507,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             } else {
                 HttpTransport::new(router)
                     .disable_origin_validation()
+                    .auto_reinitialize_sessions(true)
                     .layer(builder.layer(McpTracingLayer::new()).into_inner())
             };
 


### PR DESCRIPTION
## Summary

Enables `HttpTransport::auto_reinitialize_sessions(true)` (available since tower-mcp 0.10.1, now on `main` via #127). When a client presents an **unknown session id**, the server transparently re-initializes the session and serves the request instead of returning `-32005` "Session not found or expired".

## Why this fixes #97

#97 root cause (confirmed by local repro): the in-memory session store is wiped on every deploy/restart, so every connected client's next request hits `-32005` and reconnect-loops -- the steady `GET /` churn. With auto-reinit, that unknown session is recovered in place:

| Stale session id | Before | After |
|---|---|---|
| `POST tools/list` | `-32005` error | serves the tool list (29 tools) |
| `GET /` (SSE) | `-32005` error | HTTP 200, stream **held open** |

Server logs `Auto-reinitializing unknown session session_id=...` on recovery.

## Mechanism / scope

- tower-mcp's session resolution tries: live session -> persistent `SessionStore` -> (opt-in) auto-reinitialize. The auto-reinit path is **standalone** -- it needs no external store, which is exactly right for our single-instance deployment (the upstream doc: *"Useful for single-instance restarts where no external store is configured"*).
- Trade-off: an auto-recovered session loses the original client's identity/capabilities (the server sees client `"auto-recovered"` with default capabilities). Harmless for this server's read-only crates.io tools.
- This addresses the **dominant** churn trigger (stale sessions after deploy). The deeper cross-instance persistence / horizontal-scaling story stays under #93; combined with deploy-on-release (#129, fewer deploys), the residual churn should be minimal.

## Testing

`fmt`, `clippy -D warnings`, 212 lib + 40 integration tests pass. Behavior verified with a live local round-trip presenting a stale session id (results in the table above); the auto-reinit logic itself is owned and unit-tested upstream in tower-mcp.

Closes #97.