### PR TITLE
fix: restore auto_start_machines=true to fix Fly outage

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -11,9 +11,12 @@ primary_region = "sjc"
   internal_port = 3000
   force_https = true
   auto_stop_machines = "suspend"
-  auto_start_machines = false
-  # Single-instance is the deliberate design for this demo/reference deployment.
-  # MCP sessions are in-memory; scale-out would require a shared session store (see #93).
+  # auto_start_machines MUST stay true: with suspend + min_machines_running, the
+  # Fly proxy needs auto-start to wake/replace the single machine after it stops
+  # (e.g. post-deploy). Setting it false left the app with zero serving machines
+  # after a deploy (HTTP 000 outage). Single-instance is still enforced by
+  # min_machines_running = 1 + max below; in-memory sessions, see #93.
+  auto_start_machines = true
   min_machines_running = 1
   processes = ["app"]
   [http_service.concurrency]


### PR DESCRIPTION
## Incident

After the v0.2.0 release deploy, `cratesio-mcp.fly.dev` returned **HTTP 000** -- `fly machine list` showed **no machines**. Real users (the live Claude Code/Copilot traffic) hit a dead endpoint.

## Root cause

Not the v0.2.0 code -- the logs show both machines started cleanly (`Serving over HTTP ... MCP HTTP transport listening on 0.0.0.0:3000`), then got SIGTERM'd post-deploy and never came back.

The cause is the `fly.toml` change from #126, which set:

```toml
auto_stop_machines = "suspend"
auto_start_machines = false   # <- the bug
min_machines_running = 1
```

With `auto_start_machines = false`, the Fly proxy will not wake or replace the single machine after it stops/suspends, and `min_machines_running` can't be honored. It was latent all along -- constant traffic kept the machine from ever suspending -- until the deploy cycled the machines, after which nothing restarted them.

## Fix

Restore `auto_start_machines = true` (the pre-#126 known-good that served fine for the whole session). Single-instance intent is still enforced by `min_machines_running = 1` + the concurrency limits. In-memory session persistence remains tracked under #93.

Recovered production with a manual `fly deploy` (merges no longer auto-deploy, per #129); this PR makes the fix permanent in `main`.