### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1] - 2026-06-11
+
+### Bug Fixes
+
+- Restore auto_start_machines=true to fix Fly outage ([#131](https://github.com/joshrotenberg/cratesio-mcp/pull/131))
+- Keep Fly machine always-on (disable auto-stop) to end outage cycle ([#135](https://github.com/joshrotenberg/cratesio-mcp/pull/135))
+- Bypass response cache by a process-unique nonce, not request id ([#136](https://github.com/joshrotenberg/cratesio-mcp/pull/136))
+
+### Documentation
+
+- Feature the built-in crates.io client prominently in the README ([#139](https://github.com/joshrotenberg/cratesio-mcp/pull/139))
+
+### Miscellaneous Tasks
+
+- Add Fly health check and harden deploy verify step (closes #133) ([#137](https://github.com/joshrotenberg/cratesio-mcp/pull/137))
+
+
+
 ## [0.2.0] - 2026-06-11
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "cratesio-mcp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cratesio-mcp"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP server for querying crates.io - the Rust package registry"


### PR DESCRIPTION



## 🤖 New release

* `cratesio-mcp`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1] - 2026-06-11

### Bug Fixes

- Restore auto_start_machines=true to fix Fly outage ([#131](https://github.com/joshrotenberg/cratesio-mcp/pull/131))
- Keep Fly machine always-on (disable auto-stop) to end outage cycle ([#135](https://github.com/joshrotenberg/cratesio-mcp/pull/135))
- Bypass response cache by a process-unique nonce, not request id ([#136](https://github.com/joshrotenberg/cratesio-mcp/pull/136))

### Documentation

- Feature the built-in crates.io client prominently in the README ([#139](https://github.com/joshrotenberg/cratesio-mcp/pull/139))

### Miscellaneous Tasks

- Add Fly health check and harden deploy verify step (closes #133) ([#137](https://github.com/joshrotenberg/cratesio-mcp/pull/137))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).