### PR TITLE
fix: keep Fly machine always-on to end the outage cycle

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -10,12 +10,12 @@ primary_region = "sjc"
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = "suspend"
-  # auto_start_machines MUST stay true: with suspend + min_machines_running, the
-  # Fly proxy needs auto-start to wake/replace the single machine after it stops
-  # (e.g. post-deploy). Setting it false left the app with zero serving machines
-  # after a deploy (HTTP 000 outage). Single-instance is still enforced by
-  # min_machines_running = 1 + max below; in-memory sessions, see #93.
+  # Keep the single machine always-on (no idle auto-stop/suspend). When the app
+  # is briefly down, real client traffic backs off, so a freshly-deployed machine
+  # is immediately idle -- auto-stop then stops it before traffic returns, leaving
+  # zero serving machines (the HTTP 000 outage we hit). For a small always-on
+  # service this lifecycle churn isn't worth it; just keep the machine running.
+  auto_stop_machines = "off"
   auto_start_machines = true
   min_machines_running = 1
   processes = ["app"]


### PR DESCRIPTION
## Why (follow-up to #131)

The outage **recurred** even after #131 restored `auto_start_machines = true`. The machine lifecycle in the logs:

```
machine created -> "Serving over HTTP" -> SIGTERM/SIGINT -> "reboot: Restarting system" -> (repeat) -> zero machines
```

The binary is fine. The cause is `auto_stop_machines = "suspend"` interacting with the outage:

- All session the server had ~10 req/s of real traffic, so it was never idle and `auto_stop` never fired.
- Once the app was **down**, real clients backed off and traffic dried up. Now every freshly-deployed machine is **immediately idle**, so `auto_stop` stops it before traffic returns -- and `auto_start` can't wake a machine that has no traffic. Result: a **down-stays-down cycle**, ending in zero serving machines.

## Fix

Set `auto_stop_machines = "off"` -- keep the single machine always running. For a small ~256MB always-on service with real adoption (it ran continuously under load all session), the idle-suspend lifecycle isn't worth the churn it causes. `min_machines_running = 1` stays; in-memory sessions remain tracked under #93.

## Deploy

Recovers production with a manual `fly deploy` from this branch (or merge + `workflow_dispatch`). This branch is off current `main`, so it also carries the correct **0.2.0** version (the emergency #131 recovery deployed a pre-bump branch that reported 0.1.4).

Relates to #133 (deploy fail-safe / self-healing follow-ups).