### PR TITLE
fix: bypass response cache by a process-unique nonce, not request id

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -465,9 +465,19 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                                 let args_str = serde_json::to_string(arguments).unwrap_or_default();
                                 format!("tool:{}:{}", name, args_str)
                             }
-                            // For all other requests, use unique key based on request ID
-                            // This ensures they're never cached (each request ID is unique)
-                            _ => format!("nocache:{:?}", req.id),
+                            // All other methods bypass the cache. Use a
+                            // process-unique counter -- NOT the client-supplied
+                            // request id, which a client may reuse and thereby
+                            // collide on a stale entry (see #132) -- so each
+                            // non-tool request gets a key that can never hit.
+                            _ => {
+                                use std::sync::atomic::{AtomicU64, Ordering};
+                                static NON_TOOL_NONCE: AtomicU64 = AtomicU64::new(0);
+                                format!(
+                                    "nocache:{}",
+                                    NON_TOOL_NONCE.fetch_add(1, Ordering::Relaxed)
+                                )
+                            }
                         }
                     })
                     .on_hit(|| tracing::debug!("Cache hit"))


### PR DESCRIPTION
## Summary

Fixes the cache footgun in #132: non-tool requests (`*/list`, `prompts/get`, `resources/read`) were keyed by the client-supplied JSON-RPC `id` (`nocache:{id}`), which assumes ids are unique. A client that reuses an `id` gets a **stale cached response for a different method**.

## Fix

Key the cache-bypass path by a **process-unique `AtomicU64` counter** instead of `req.id`, so every non-tool request gets a key that can never hit the cache -- independent of what the client sends.

```rust
_ => {
    use std::sync::atomic::{AtomicU64, Ordering};
    static NON_TOOL_NONCE: AtomicU64 = AtomicU64::new(0);
    format!("nocache:{}", NON_TOOL_NONCE.fetch_add(1, Ordering::Relaxed))
}
```

Tool calls are unchanged (still content-keyed `tool:{name}:{args}`).

## Verification

Reproduced the bug and confirmed the fix on a local HTTP server:
- `prompts/list` with `id:7` -> returns the prompt list
- `prompts/get` with the **same** `id:7` -> **now returns the correct prompt** (previously returned the cached `prompts/list`)

`fmt`, `clippy -D warnings`, lib + integration tests all pass.

Closes #132.