### PR TITLE
ci: add Fly health check and harden deploy verify step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,17 +40,21 @@ jobs:
       - name: Verify deployment (health check)
         run: |
           echo "Waiting for server to be ready..."
-          sleep 10
-
-          echo "Checking health endpoint..."
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://cratesio-mcp.fly.dev/health)
-
-          if [ "$HTTP_STATUS" = "200" ]; then
-            echo "Health check passed!"
-          else
-            echo "Health check failed with status: $HTTP_STATUS"
-            exit 1
-          fi
+          MAX_RETRIES=6
+          RETRY_DELAY=10
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            # Tolerate transient connect/TLS errors while the machine comes up
+            # (a single early curl false-failed the v0.2.0 release run).
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://cratesio-mcp.fly.dev/health || echo "000")
+            echo "Attempt $attempt/$MAX_RETRIES: HTTP $HTTP_STATUS"
+            if [ "$HTTP_STATUS" = "200" ]; then
+              echo "Health check passed!"
+              exit 0
+            fi
+            sleep $RETRY_DELAY
+          done
+          echo "Health check failed after $MAX_RETRIES attempts"
+          exit 1
 
       - name: Verify deployment (MCP protocol)
         run: |

--- a/fly.toml
+++ b/fly.toml
@@ -24,6 +24,16 @@ primary_region = "sjc"
     hard_limit = 35
     soft_limit = 25
 
+  # Fly-managed HTTP health check on /health. A failing check makes a deploy
+  # fail (instead of "succeeding" while the app serves nothing -- the gap that
+  # hid the v0.2.0 outage) and stops the proxy routing to an unhealthy machine.
+  [[http_service.checks]]
+    interval = "15s"
+    timeout = "5s"
+    grace_period = "10s"
+    method = "GET"
+    path = "/health"
+
 [[vm]]
   memory = "256mb"
   cpu_kind = "shared"


### PR DESCRIPTION
## Summary

Post-incident hardening (#133) so a config/deploy error can't silently take production down again.

### 1. Fly-managed health check (`fly.toml`)
Adds `[[http_service.checks]]` on `/health`:
```toml
[[http_service.checks]]
  interval = "15s"
  timeout = "5s"
  grace_period = "10s"
  method = "GET"
  path = "/health"
```
Fly now **fails a deploy whose new machine doesn't actually serve** -- the exact gap that hid the v0.2.0 outage (`flyctl deploy` reported success while the app was down) -- and the proxy stops routing to an unhealthy machine.

### 2. Harden the deploy verify-health step (`deploy.yml`)
The step did a single `curl` 10s after deploy with no retry, which **false-failed the v0.2.0 release run** on a transient SSL error even though the machine came up. Now it retries (6x / 10s, ~60s, tolerating transient connect/TLS errors) -- mirroring the existing MCP-verify step.

## Scope

Items 1 and 2 from #133. Item 3 (proactive uptime alerting) is left as a possible separate follow-up.

Validated: `fly.toml` parses as TOML with the checks table, `deploy.yml` parses as YAML.

Closes #133.