### PR TITLE
fix: correct client endpoint paths to match the crates.io OpenAPI spec

### DIFF
--- a/src/client/owners.rs
+++ b/src/client/owners.rs
@@ -89,7 +89,7 @@ impl CratesIoClient {
     /// Accept an owner invitation using a token (from email link).
     pub async fn accept_invitation_by_token(&self, token: &str) -> Result<u64, Error> {
         let resp: InvitationTokenResponse = self
-            .put_empty_json(&format!("/crate_owner_invitations/{token}"))
+            .put_empty_json(&format!("/me/crate_owner_invitations/accept/{token}"))
             .await?;
         Ok(resp.crate_owner_invitation.crate_id)
     }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -1444,7 +1444,7 @@ async fn accept_invitation_by_token_sends_put() {
     let server = MockServer::start().await;
 
     Mock::given(method("PUT"))
-        .and(path("/crate_owner_invitations/abc123"))
+        .and(path("/me/crate_owner_invitations/accept/abc123"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "crate_owner_invitation": {
                 "accepted": true,
@@ -1638,7 +1638,7 @@ async fn list_github_configs_returns_list() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/trustpub/github_configs"))
+        .and(path("/trusted_publishing/github_configs"))
         .and(header("Authorization", "test-token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "github_configs": [{
@@ -1672,7 +1672,7 @@ async fn create_github_config_sends_post() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
-        .and(path("/trustpub/github_configs"))
+        .and(path("/trusted_publishing/github_configs"))
         .and(header("Authorization", "test-token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "github_config": {
@@ -1710,7 +1710,7 @@ async fn delete_github_config_sends_delete() {
     let server = MockServer::start().await;
 
     Mock::given(method("DELETE"))
-        .and(path("/trustpub/github_configs/1"))
+        .and(path("/trusted_publishing/github_configs/1"))
         .and(header("Authorization", "test-token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
         .expect(1)
@@ -1728,7 +1728,7 @@ async fn list_gitlab_configs_returns_list() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/trustpub/gitlab_configs"))
+        .and(path("/trusted_publishing/gitlab_configs"))
         .and(header("Authorization", "test-token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "gitlab_configs": [{
@@ -1759,7 +1759,7 @@ async fn create_gitlab_config_sends_post() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
-        .and(path("/trustpub/gitlab_configs"))
+        .and(path("/trusted_publishing/gitlab_configs"))
         .and(header("Authorization", "test-token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "gitlab_config": {
@@ -1793,7 +1793,7 @@ async fn delete_gitlab_config_sends_delete() {
     let server = MockServer::start().await;
 
     Mock::given(method("DELETE"))
-        .and(path("/trustpub/gitlab_configs/1"))
+        .and(path("/trusted_publishing/gitlab_configs/1"))
         .and(header("Authorization", "test-token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
         .expect(1)
@@ -1811,7 +1811,7 @@ async fn exchange_oidc_token_sends_post() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
-        .and(path("/trustpub/tokens/exchange"))
+        .and(path("/trusted_publishing/tokens"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "token": "cio-publish-token-abc"
         })))
@@ -1833,7 +1833,7 @@ async fn revoke_trusted_token_sends_delete() {
     let server = MockServer::start().await;
 
     Mock::given(method("DELETE"))
-        .and(path("/trustpub/tokens/42"))
+        .and(path("/trusted_publishing/tokens"))
         .and(header("Authorization", "test-token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
         .expect(1)
@@ -1841,7 +1841,7 @@ async fn revoke_trusted_token_sends_delete() {
         .await;
 
     let client = test_client(&server.uri()).with_auth("test-token");
-    client.revoke_trusted_token(42).await.unwrap();
+    client.revoke_trusted_token().await.unwrap();
 }
 
 // ── retry ────────────────────────────────────────────────────────────────────

--- a/src/client/trusted.rs
+++ b/src/client/trusted.rs
@@ -16,7 +16,9 @@ impl CratesIoClient {
     ///
     /// Requires authentication.
     pub async fn list_github_configs(&self) -> Result<Vec<GitHubConfig>, Error> {
-        let resp: GitHubConfigsResponse = self.get_json_auth("/trustpub/github_configs").await?;
+        let resp: GitHubConfigsResponse = self
+            .get_json_auth("/trusted_publishing/github_configs")
+            .await?;
         Ok(resp.github_configs)
     }
 
@@ -30,7 +32,9 @@ impl CratesIoClient {
         let body = CreateGitHubConfigRequest {
             github_config: config,
         };
-        let resp: GitHubConfigResponse = self.post_json("/trustpub/github_configs", &body).await?;
+        let resp: GitHubConfigResponse = self
+            .post_json("/trusted_publishing/github_configs", &body)
+            .await?;
         Ok(resp.github_config)
     }
 
@@ -38,7 +42,7 @@ impl CratesIoClient {
     ///
     /// Requires authentication.
     pub async fn delete_github_config(&self, id: u64) -> Result<(), Error> {
-        self.delete_ok(&format!("/trustpub/github_configs/{id}"))
+        self.delete_ok(&format!("/trusted_publishing/github_configs/{id}"))
             .await
     }
 
@@ -48,7 +52,9 @@ impl CratesIoClient {
     ///
     /// Requires authentication.
     pub async fn list_gitlab_configs(&self) -> Result<Vec<GitLabConfig>, Error> {
-        let resp: GitLabConfigsResponse = self.get_json_auth("/trustpub/gitlab_configs").await?;
+        let resp: GitLabConfigsResponse = self
+            .get_json_auth("/trusted_publishing/gitlab_configs")
+            .await?;
         Ok(resp.gitlab_configs)
     }
 
@@ -62,7 +68,9 @@ impl CratesIoClient {
         let body = CreateGitLabConfigRequest {
             gitlab_config: config,
         };
-        let resp: GitLabConfigResponse = self.post_json("/trustpub/gitlab_configs", &body).await?;
+        let resp: GitLabConfigResponse = self
+            .post_json("/trusted_publishing/gitlab_configs", &body)
+            .await?;
         Ok(resp.gitlab_config)
     }
 
@@ -70,7 +78,7 @@ impl CratesIoClient {
     ///
     /// Requires authentication.
     pub async fn delete_gitlab_config(&self, id: u64) -> Result<(), Error> {
-        self.delete_ok(&format!("/trustpub/gitlab_configs/{id}"))
+        self.delete_ok(&format!("/trusted_publishing/gitlab_configs/{id}"))
             .await
     }
 
@@ -85,15 +93,18 @@ impl CratesIoClient {
             jwt: jwt.to_string(),
         };
         let resp: OidcExchangeResponse = self
-            .post_json_unauth("/trustpub/tokens/exchange", &body)
+            .post_json_unauth("/trusted_publishing/tokens", &body)
             .await?;
         Ok(resp.token)
     }
 
-    /// Revoke a trusted publishing token.
+    /// Revoke the current temporary trusted-publishing access token.
     ///
-    /// Requires authentication.
-    pub async fn revoke_trusted_token(&self, id: u64) -> Result<(), Error> {
-        self.delete_ok(&format!("/trustpub/tokens/{id}")).await
+    /// Per the crates.io API this revokes the temporary token previously
+    /// obtained from [`exchange_oidc_token`](Self::exchange_oidc_token); the
+    /// endpoint takes no id and is authenticated by that temporary token
+    /// itself (not a regular crates.io API token).
+    pub async fn revoke_trusted_token(&self) -> Result<(), Error> {
+        self.delete_ok("/trusted_publishing/tokens").await
     }
 }


### PR DESCRIPTION
## Summary

Part of the #138 client audit. Diffing the client against the **crates.io OpenAPI spec** (`https://crates.io/api/openapi.json`, 40 documented paths) surfaced endpoint paths that don't match the live API. All are authenticated **write** endpoints -- never hit by the read-path tools, and the wiremock tests pinned the client's *own* wrong paths, so they passed against a contract that doesn't exist.

## Fixes

**Trusted publishing** -- spec uses `/trusted_publishing`, the client used `/trustpub`:
| Method | Was | Now (per spec) |
|--------|-----|----------------|
| list/create/delete `github_configs` | `/trustpub/github_configs[/{id}]` | `/trusted_publishing/github_configs[/{id}]` |
| list/create/delete `gitlab_configs` | `/trustpub/gitlab_configs[/{id}]` | `/trusted_publishing/gitlab_configs[/{id}]` |
| `exchange_oidc_token` | `POST /trustpub/tokens/exchange` | `POST /trusted_publishing/tokens` |
| `revoke_trusted_token` | `DELETE /trustpub/tokens/{id}` | `DELETE /trusted_publishing/tokens` |

The revoke endpoint takes **no id** in the spec and is authenticated by the temporary token itself, so the `id` parameter was dropped and the auth mechanism documented.

**Owner invitations:**
| Method | Was | Now (per spec) |
|--------|-----|----------------|
| `accept_invitation_by_token` | `PUT /crate_owner_invitations/{token}` | `PUT /me/crate_owner_invitations/accept/{token}` |

## Testing

`fmt`, `clippy -D warnings`, 212 lib tests pass (wiremock mocks updated to the corrected paths).

## Caveat

These are auth-required endpoints that can't be live-verified without credentials; paths/methods are aligned to the authoritative OpenAPI spec. The trusted-publishing **token revoke** additionally needs the temporary-token auth flow wired up to actually function -- tracked under #138.