### PR TITLE
feat: add a client-only Cargo feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,18 @@ jobs:
       - run: cargo test --lib
       - run: cargo test --doc
 
+  client-only:
+    name: Client-only feature
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Build + test the library with just the `client` feature (no MCP stack),
+      # so the client-only consumer path can't bit-rot.
+      - run: cargo clippy --no-default-features --features client --lib -- -D warnings
+      - run: cargo test --no-default-features --features client --lib
+
   msrv:
     name: MSRV (1.90)
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,29 @@ path = "src/lib.rs"
 [[bin]]
 name = "cratesio-mcp"
 path = "src/main.rs"
+required-features = ["mcp"]
+
+[features]
+default = ["mcp"]
+# The crates.io + docs.rs + OSV client library only, no MCP server machinery.
+# Use with `default-features = false, features = ["client"]`.
+client = []
+# The full MCP server: tools, prompts, resources, and both transports.
+mcp = [
+    "dep:tower-mcp",
+    "dep:axum",
+    "dep:clap",
+    "dep:schemars",
+    "dep:tracing-subscriber",
+    "dep:tower",
+    "dep:tower-resilience",
+]
 
 [dependencies]
-# Core MCP
-tower-mcp = { version = "0.12", features = ["http", "testing"] }
+# Core MCP (server only)
+tower-mcp = { version = "0.12", features = ["http", "testing"], optional = true }
 # HTTP server types, for the client-IP request-logging middleware on the HTTP transport
-axum = "0.8"
+axum = { version = "0.8", optional = true }
 
 # HTTP client for crates.io API
 reqwest = { version = "0.12", features = ["json", "gzip"] }
@@ -35,24 +52,24 @@ thiserror = "2"
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 
-# CLI
-clap = { version = "4", features = ["derive"] }
+# CLI (server binary only)
+clap = { version = "4", features = ["derive"], optional = true }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
-# Schema generation
-schemars = "1"
+# Schema generation (MCP tool input schemas)
+schemars = { version = "1", optional = true }
 
 # Tracing
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
-# Tower middleware
-tower = { version = "0.5", features = ["util", "timeout", "limit"] }
+# Tower middleware (server only)
+tower = { version = "0.5", features = ["util", "timeout", "limit"], optional = true }
 # 0.7.1 adds SharedCacheLayer for cross-session cache sharing
-tower-resilience = { version = "0.7.1", default-features = false, features = ["bulkhead", "ratelimiter", "cache"] }
+tower-resilience = { version = "0.7.1", default-features = false, features = ["bulkhead", "ratelimiter", "cache"], optional = true }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,25 @@
+//! An MCP server for crates.io, plus a standalone async crates.io API client.
+//!
+//! # Cargo features
+//!
+//! - **`mcp`** (default) -- the full MCP server: `tools`, `prompts`,
+//!   `resources`, shared `state`, and both transports. Required by the
+//!   `cratesio-mcp` binary.
+//! - **`client`** -- the [`client`] (crates.io / docs.rs / OSV) and [`docs`]
+//!   library only, with none of the MCP server dependencies. Depend on it with:
+//!   `cratesio-mcp = { version = "...", default-features = false, features = ["client"] }`.
+
 pub mod client;
 pub mod docs;
+
+// MCP server modules -- gated behind the `mcp` feature (the default).
+// Disable with `default-features = false, features = ["client"]` to use just
+// the crates.io / docs.rs / OSV client library.
+#[cfg(feature = "mcp")]
 pub mod prompts;
+#[cfg(feature = "mcp")]
 pub mod resources;
+#[cfg(feature = "mcp")]
 pub mod state;
+#[cfg(feature = "mcp")]
 pub mod tools;

--- a/tests/mcp_integration.rs
+++ b/tests/mcp_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "mcp")]
 //! MCP integration tests using tower-mcp's TestClient + wiremock.
 //!
 //! These tests exercise the full JSON-RPC pipeline: client request -> router ->


### PR DESCRIPTION
## Summary

Closes #141. Lets downstream users depend on just the crates.io / docs.rs / OSV **client library** without the MCP server stack:

```toml
cratesio-mcp = { version = "0.2", default-features = false, features = ["client"] }
```

This pairs with the README billing (#139) -- the client is now actually consumable standalone, and its read **+ write** API (publish, owners, tokens, trusted publishing) has a proper home for programmatic (non-agent) use.

## Changes

- **Features:** `default = ["mcp"]`, `client = []`, `mcp = ["dep:tower-mcp", "dep:axum", "dep:clap", "dep:schemars", "dep:tracing-subscriber", "dep:tower", "dep:tower-resilience"]`. Those deps are now `optional`.
- **`#[cfg(feature = "mcp")]`** on the `state` / `tools` / `prompts` / `resources` module declarations. `client/` and `docs/` were already 100% MCP-free, so no code refactor was needed.
- **Binary** gets `required-features = ["mcp"]`; the MCP integration tests get `#![cfg(feature = "mcp")]`.
- **New CI job** (`Client-only feature`) runs `clippy`/`test` with `--no-default-features --features client` so the path can't bit-rot.
- Crate-level docs document the two features.

## Verification

| Config | Result |
|--------|--------|
| `--no-default-features --features client` | builds; `cargo tree` shows **none** of tower-mcp/axum/schemars/tower-resilience; **109** lib tests pass; clippy + doc clean |
| default (`mcp`) | unchanged -- **212** lib + **40** integration + **2** doc tests; clippy `-D warnings` + doc clean |

## Note (no code)

Documents the deliberate boundary from the #138 audit: **reads are exposed via the MCP tool surface; writes (publish/yank/owners/tokens/trusted-publishing) are library-only and intentionally not agent-accessible.** The audit confirmed nothing is missing from the MCP surface.