### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-06-11
+
+### Bug Fixes
+
+- Restore auto_start_machines=true to fix Fly outage ([#131](https://github.com/joshrotenberg/cratesio-mcp/pull/131))
+- Keep Fly machine always-on (disable auto-stop) to end outage cycle ([#135](https://github.com/joshrotenberg/cratesio-mcp/pull/135))
+- Bypass response cache by a process-unique nonce, not request id ([#136](https://github.com/joshrotenberg/cratesio-mcp/pull/136))
+- Correct client endpoint paths to match the crates.io OpenAPI spec ([#140](https://github.com/joshrotenberg/cratesio-mcp/pull/140))
+
+### Documentation
+
+- Feature the built-in crates.io client prominently in the README ([#139](https://github.com/joshrotenberg/cratesio-mcp/pull/139))
+
+### Miscellaneous Tasks
+
+- Add Fly health check and harden deploy verify step (closes #133) ([#137](https://github.com/joshrotenberg/cratesio-mcp/pull/137))
+
+
+
 ## [0.2.0] - 2026-06-11
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "cratesio-mcp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cratesio-mcp"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP server for querying crates.io - the Rust package registry"


### PR DESCRIPTION



## 🤖 New release

* `cratesio-mcp`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `cratesio-mcp` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  cratesio_mcp::client::CratesIoClient::revoke_trusted_token takes 1 parameters in /tmp/.tmpkPDSmq/cratesio-mcp/src/client/trusted.rs:96, but now takes 0 parameters in /tmp/.tmpOkChut/cratesio-mcp/src/client/trusted.rs:107
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0] - 2026-06-11

### Bug Fixes

- Restore auto_start_machines=true to fix Fly outage ([#131](https://github.com/joshrotenberg/cratesio-mcp/pull/131))
- Keep Fly machine always-on (disable auto-stop) to end outage cycle ([#135](https://github.com/joshrotenberg/cratesio-mcp/pull/135))
- Bypass response cache by a process-unique nonce, not request id ([#136](https://github.com/joshrotenberg/cratesio-mcp/pull/136))
- Correct client endpoint paths to match the crates.io OpenAPI spec ([#140](https://github.com/joshrotenberg/cratesio-mcp/pull/140))

### Documentation

- Feature the built-in crates.io client prominently in the README ([#139](https://github.com/joshrotenberg/cratesio-mcp/pull/139))

### Miscellaneous Tasks

- Add Fly health check and harden deploy verify step (closes #133) ([#137](https://github.com/joshrotenberg/cratesio-mcp/pull/137))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).