### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-06-12
+
+### Bug Fixes
+
+- Reap only stopped/suspended machines, not in-flight ones ([#145](https://github.com/joshrotenberg/cratesio-mcp/pull/145))
+
+### Miscellaneous Tasks
+
+- Finish the client audit follow-ups (closes #138) ([#146](https://github.com/joshrotenberg/cratesio-mcp/pull/146))
+
+
+
 ## [0.2.1] - 2026-06-11
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "cratesio-mcp"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cratesio-mcp"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP server for querying crates.io - the Rust package registry"


### PR DESCRIPTION



## 🤖 New release

* `cratesio-mcp`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `cratesio-mcp` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  cratesio_mcp::client::CratesIoClient::revoke_trusted_token takes 0 parameters in /tmp/.tmpy642MM/cratesio-mcp/src/client/trusted.rs:107, but now takes 1 parameters in /tmp/.tmpvWSoO9/cratesio-mcp/src/client/trusted.rs:107
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0] - 2026-06-12

### Bug Fixes

- Reap only stopped/suspended machines, not in-flight ones ([#145](https://github.com/joshrotenberg/cratesio-mcp/pull/145))

### Miscellaneous Tasks

- Finish the client audit follow-ups (closes #138) ([#146](https://github.com/joshrotenberg/cratesio-mcp/pull/146))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).