### PR TITLE
fix: reap only stopped/suspended machines, not in-flight ones

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,13 @@ jobs:
 
       - name: Reap stale machines
         run: |
+          # Only reap genuinely-stale machines (stopped/suspended leftovers).
+          # NOT `state != "started"` -- with --strategy immediate the freshly
+          # deployed machine is briefly in "created"/"replacing" state when this
+          # runs, and the broad filter destroyed it, leaving zero machines (an
+          # HTTP 000 outage). With auto_stop = "off" there should be none anyway.
           echo "Destroying any stopped/suspended machines left from the deploy..."
-          flyctl machines list --json | jq -r '.[] | select(.state != "started") | .id' | xargs -I{} flyctl machines destroy {} --force || true
+          flyctl machines list --json | jq -r '.[] | select(.state == "stopped" or .state == "suspended") | .id' | xargs -I{} flyctl machines destroy {} --force || true
           echo "Active machines after reap:"
           flyctl machines list
         env:


### PR DESCRIPTION
## Incident

The v0.2.1 deploy failed and took the server down (HTTP 000). The deploy log:

```
machine 6e820e00ae0e58 was found and is currently in replacing state, attempting to destroy...
6e820e00ae0e58 has been destroyed
machine 6e820e03b36de8 was found and is currently in created state, attempting to destroy...
6e820e03b36de8 has been destroyed
No machines are available on this app cratesio-mcp
```

## Cause

The "Reap stale machines" step used `select(.state != "started")`. With `--strategy immediate`, the freshly deployed machine is briefly in `created` / `replacing` state when the reap runs -- so the broad filter destroyed the **new** machine, leaving zero. The step's own echo says it targets "stopped/suspended" machines; the filter was wrong.

## Fix

Narrow the reap to the genuinely-stale states:

```diff
- select(.state != "started")
+ select(.state == "stopped" or .state == "suspended")
```

With `auto_stop = "off"` there shouldn't be any to reap anyway, so this is effectively a safe no-op that can't eat an in-flight machine.

## Silver lining

The new Fly `/health` check + the verify-retry step (from #137) **worked as intended** -- they failed the deploy loudly instead of letting it silently leave the app down. That's exactly the fail-safe behavior #133 was about.