### PR TITLE
chore: finish the client audit follow-ups (closes #138)

### DIFF
--- a/scripts/audit-client-endpoints.sh
+++ b/scripts/audit-client-endpoints.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Diff the built-in crates.io client's endpoints against the live crates.io
+# OpenAPI spec, to catch API drift (paths that no longer match the registry).
+#
+# This is the check that surfaced the /trustpub -> /trusted_publishing rename
+# and the owner-invitation accept path bug (issue #138): the wiremock tests pin
+# the client's *own* paths, so only a diff against the authoritative spec can
+# catch contract drift. Run it periodically.
+#
+# Informational only -- prints findings, never fails. Some "in spec, not
+# implemented" entries are intentionally out of scope (account-email ops, the
+# .crate file download); some "client, not in spec" entries are real private
+# endpoints the spec simply doesn't document (/me/*, follow).
+#
+# Usage:  ./scripts/audit-client-endpoints.sh
+# Needs:  curl, jq
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+SPEC_URL="https://crates.io/api/openapi.json"
+spec="$(mktemp)"
+trap 'rm -f "$spec" "$spec.spec" "$spec.client"' EXIT
+
+curl -sf -H "User-Agent: cratesio-mcp-endpoint-audit" "$SPEC_URL" -o "$spec"
+
+# Spec paths: strip the /api/v1 prefix and normalize {param} -> {}.
+jq -r '.paths | keys[]' "$spec" \
+  | sed -E 's#^/api/v1##; s#\{[^}]+\}#{}#g' | sort -u > "$spec.spec"
+
+# Client paths: pull path-string literals from the endpoint modules and
+# normalize the same way.
+grep -rhoE '"/[a-zA-Z0-9_./{}-]+"' \
+  src/client/{crates,versions,owners,categories,keywords,users,teams,tokens,trusted,publish,metadata}.rs \
+  | tr -d '"' | sed -E 's#\{[^}]+\}#{}#g' | grep -E '^/' | sort -u > "$spec.client"
+
+echo "spec: $(wc -l < "$spec.spec" | tr -d ' ') paths    client: $(wc -l < "$spec.client" | tr -d ' ') paths"
+echo
+echo "## In spec but NOT implemented by the client (gaps; some intentionally out of scope):"
+comm -23 "$spec.spec" "$spec.client" | sed 's/^/  /' || true
+echo
+echo "## Client paths NOT in the spec (renamed/deprecated, or undocumented private endpoints -- review):"
+comm -13 "$spec.spec" "$spec.client" | sed 's/^/  /' || true

--- a/src/client/changelog.rs
+++ b/src/client/changelog.rs
@@ -91,6 +91,82 @@ fn parse_github_repo(url: &str) -> Option<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::CratesIoClient;
+    use std::time::Duration;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn crate_json(name: &str, repository: Option<&str>) -> serde_json::Value {
+        let mut c = serde_json::json!({
+            "name": name,
+            "max_version": "1.0.0",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z",
+        });
+        if let Some(r) = repository {
+            c["repository"] = serde_json::json!(r);
+        }
+        serde_json::json!({ "crate": c, "versions": [] })
+    }
+
+    #[tokio::test]
+    async fn fetch_changelog_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/mycrate"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(crate_json("mycrate", Some("https://github.com/owner/repo"))),
+            )
+            .mount(&server)
+            .await;
+        // First filename tried (CHANGELOG.md) resolves on the raw host.
+        Mock::given(method("GET"))
+            .and(path("/owner/repo/HEAD/CHANGELOG.md"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("# Changelog\n\n## 1.0.0\n- initial"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = CratesIoClient::with_base_url(
+            "test",
+            Duration::from_millis(0),
+            Duration::from_secs(5),
+            &server.uri(),
+        )
+        .unwrap()
+        .with_github_raw_url(&server.uri());
+        match client.fetch_changelog("mycrate").await.unwrap() {
+            ChangelogResult::Found { filename, content } => {
+                assert_eq!(filename, "CHANGELOG.md");
+                assert!(content.contains("# Changelog"));
+            }
+            _ => panic!("expected ChangelogResult::Found"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_changelog_no_repository() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/crates/norepo"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(crate_json("norepo", None)))
+            .mount(&server)
+            .await;
+
+        let client = CratesIoClient::with_base_url(
+            "test",
+            Duration::from_millis(0),
+            Duration::from_secs(5),
+            &server.uri(),
+        )
+        .unwrap();
+        assert!(matches!(
+            client.fetch_changelog("norepo").await.unwrap(),
+            ChangelogResult::NoRepository
+        ));
+    }
 
     #[test]
     fn parse_github_repo_standard() {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -466,6 +466,23 @@ impl CratesIoClient {
         Ok(())
     }
 
+    /// DELETE that succeeds on 2xx, authenticated with an explicitly-supplied
+    /// token rather than the client's stored API token -- used for the
+    /// trusted-publishing token revoke, which is authed by the temporary token
+    /// itself.
+    pub(crate) async fn delete_ok_with_token(&self, path: &str, token: &str) -> Result<(), Error> {
+        self.throttle().await;
+        let url = format!("{}{}", self.base_url, path);
+        let resp = self
+            .http
+            .delete(&url)
+            .header("Authorization", token)
+            .send()
+            .await?;
+        Self::check_status(resp, path).await?;
+        Ok(())
+    }
+
     /// PATCH a JSON body and return deserialized response. Requires auth.
     pub(crate) async fn patch_json<T: DeserializeOwned, B: Serialize>(
         &self,

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -1832,16 +1832,20 @@ async fn exchange_oidc_token_sends_post() {
 async fn revoke_trusted_token_sends_delete() {
     let server = MockServer::start().await;
 
+    // Authed by the temporary token itself, NOT the client's stored API token.
     Mock::given(method("DELETE"))
         .and(path("/trusted_publishing/tokens"))
-        .and(header("Authorization", "test-token"))
+        .and(header("Authorization", "temp-trustpub-token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
         .expect(1)
         .mount(&server)
         .await;
 
-    let client = test_client(&server.uri()).with_auth("test-token");
-    client.revoke_trusted_token().await.unwrap();
+    let client = test_client(&server.uri()).with_auth("regular-api-token");
+    client
+        .revoke_trusted_token("temp-trustpub-token")
+        .await
+        .unwrap();
 }
 
 // ── retry ────────────────────────────────────────────────────────────────────

--- a/src/client/trusted.rs
+++ b/src/client/trusted.rs
@@ -98,13 +98,14 @@ impl CratesIoClient {
         Ok(resp.token)
     }
 
-    /// Revoke the current temporary trusted-publishing access token.
+    /// Revoke a temporary trusted-publishing access token.
     ///
-    /// Per the crates.io API this revokes the temporary token previously
-    /// obtained from [`exchange_oidc_token`](Self::exchange_oidc_token); the
-    /// endpoint takes no id and is authenticated by that temporary token
-    /// itself (not a regular crates.io API token).
-    pub async fn revoke_trusted_token(&self) -> Result<(), Error> {
-        self.delete_ok("/trusted_publishing/tokens").await
+    /// Pass the temporary `token` previously returned from
+    /// [`exchange_oidc_token`](Self::exchange_oidc_token). Per the crates.io
+    /// API the endpoint takes no id and is authenticated by that temporary
+    /// token itself, not a regular crates.io API token.
+    pub async fn revoke_trusted_token(&self, token: &str) -> Result<(), Error> {
+        self.delete_ok_with_token("/trusted_publishing/tokens", token)
+            .await
     }
 }


### PR DESCRIPTION
## Summary

Closes the three remaining items from the #138 client audit.

### 1. Trusted-publishing token revoke -- correct auth
`revoke_trusted_token(token)` now sends `DELETE /trusted_publishing/tokens` authenticated by the **temporary token** itself (via a new `delete_ok_with_token` helper), per the spec -- not the client's stored API token. The test asserts the temp token is what goes on the `Authorization` header.

### 2. `fetch_changelog` tests
Added wiremock tests (found + no-repository). The other "gaps" from the audit were false positives:
- `fetch_rustdoc` already has 5 inline tests
- `query_package` is the OSV client and is already tested

### 3. Spec-diff guard
`scripts/audit-client-endpoints.sh` packages the crates.io OpenAPI-spec diff that found the `/trustpub` and invitation-path bugs, for periodic runs. Running it now shows **zero real discrepancies** -- only intentionally out-of-scope endpoints (`/confirm`, `/users/{}/resend`, `/me/email_notifications`, the `.crate` download) and undocumented-private ones (`/me/*`, `/crates/{}/following`).

## Testing

`fmt`, `clippy -D warnings`, 214 lib + 40 integration + doc tests, `cargo doc` -- all clean.

Closes #138.