### PR TITLE
chore(deps): upgrade tower-mcp 0.12 -> 0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -193,6 +193,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "bitflags"
@@ -822,7 +828,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1418,7 +1424,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1999,13 +2005,13 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-mcp"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96dd7df8b3c0f729ce9f294059f501fd8b1c53760bf61079c1433380fe66d76b"
+checksum = "413dcd045b03e96c94c6281a026376e7f04200da3768b1f7b5c84d791deddb18"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.23.0",
  "futures",
  "http",
  "http-body-util",
@@ -2018,6 +2024,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tower",
  "tower-mcp-types",
  "tower-service",
@@ -2027,11 +2034,11 @@ dependencies = [
 
 [[package]]
 name = "tower-mcp-types"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6511f1f32c7cb7fd4525edc0eb4dcf307db8f7eceb2833ab24a37b4cc10cda61"
+checksum = "bcabb3ef9a2ffa4646c2375e90893d02a01394e3ff0ff72c3b643d90d38b2947"
 dependencies = [
- "base64",
+ "base64 0.23.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -2642,7 +2649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ mcp = [
 
 [dependencies]
 # Core MCP (server only)
-tower-mcp = { version = "0.12", features = ["http", "testing"], optional = true }
+tower-mcp = { version = "0.13", features = ["http", "testing"], optional = true }
 # HTTP server types, for the client-IP request-logging middleware on the HTTP transport
 axum = { version = "0.8", optional = true }
 

--- a/src/resources/crate_info.rs
+++ b/src/resources/crate_info.rs
@@ -58,7 +58,7 @@ pub fn build(state: Arc<AppState>) -> ResourceTemplate {
                         blob: None,
                         meta: None,
                     }],
-                    meta: None,
+                    ..Default::default()
                 })
             }
         })

--- a/src/resources/docs.rs
+++ b/src/resources/docs.rs
@@ -38,7 +38,7 @@ pub fn build(state: Arc<AppState>) -> ResourceTemplate {
                         blob: None,
                         meta: None,
                     }],
-                    meta: None,
+                    ..Default::default()
                 })
             }
         })

--- a/src/resources/readme.rs
+++ b/src/resources/readme.rs
@@ -48,7 +48,7 @@ pub fn build(state: Arc<AppState>) -> ResourceTemplate {
                         blob: None,
                         meta: None,
                     }],
-                    meta: None,
+                    ..Default::default()
                 })
             }
         })

--- a/src/resources/recent_searches.rs
+++ b/src/resources/recent_searches.rs
@@ -26,7 +26,7 @@ pub fn build(state: Arc<AppState>) -> Resource {
                         blob: None,
                         meta: None,
                     }],
-                    meta: None,
+                    ..Default::default()
                 })
             }
         })


### PR DESCRIPTION
## What

Upgrade `tower-mcp` from 0.12.0 to 0.13.1 (released 2026-07-23).

## Why

0.13.x brings the 2026-07-28 draft conformance work, task-augmented tool calls, a pluggable `TaskStore`, and client-side ordering/404 fixes. Keeping current also lines us up to evaluate the stateless (2026-07-28) path as a real multi-instance fix for #147 later.

## Changes

- `Cargo.toml`: `tower-mcp = "0.13"`; `Cargo.lock` updated to 0.13.1 (`tower-mcp-types` 0.13.1, adds `base64 0.23`).
- Adapt to one breaking change: `ReadResourceResult` gained the SEP-2549 caching-hint fields `cache_scope` and `ttl_ms`. The four resource handlers (`crate_info`, `docs`, `readme`, `recent_searches`) now fill the struct with `..Default::default()`. Both new fields default to `None` and are `skip_serializing_if = "Option::is_none"`, so the emitted `resources/read` responses are byte-for-byte unchanged on the protocol versions our clients negotiate.

## Validation

- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --all-features`: 214 + 40 + 2 doctests pass, 0 failures
- Builds: `--all-features` and `--no-default-features --features client` both compile

## Not in this PR

This does not fix #147 (multi-instance session loss); that is a deployment/session-consistency decision tracked separately.