### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2026-07-24
+
+### Documentation
+
+- Document single-instance requirement in fly.toml ([#147](https://github.com/joshrotenberg/cratesio-mcp/pull/147)) ([#150](https://github.com/joshrotenberg/cratesio-mcp/pull/150))
+- Tighten README prose and drop dash-as-punctuation ([#151](https://github.com/joshrotenberg/cratesio-mcp/pull/151))
+
+
+
 ## [0.3.0] - 2026-06-12
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "cratesio-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cratesio-mcp"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP server for querying crates.io - the Rust package registry"


### PR DESCRIPTION



## 🤖 New release

* `cratesio-mcp`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1] - 2026-07-24

### Documentation

- Document single-instance requirement in fly.toml ([#147](https://github.com/joshrotenberg/cratesio-mcp/pull/147)) ([#150](https://github.com/joshrotenberg/cratesio-mcp/pull/150))
- Tighten README prose and drop dash-as-punctuation ([#151](https://github.com/joshrotenberg/cratesio-mcp/pull/151))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).