### PR TITLE
docs: document single-instance requirement in fly.toml (#147)

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -17,6 +17,13 @@ primary_region = "sjc"
   # service this lifecycle churn isn't worth it; just keep the machine running.
   auto_stop_machines = "off"
   auto_start_machines = true
+  # Run exactly ONE machine. MCP sessions are held in-memory per instance with
+  # no shared session store and no session-sticky routing, so a second machine
+  # scatters same-session requests across instances that don't share state and
+  # the first post-initialize request fails with -32600 (#147). Note this key is
+  # a floor, not a cap: `fly launch` creates 2 machines by default and this line
+  # will not remove the extra one. Keep the count at 1 with `fly scale count 1`;
+  # only scale past 1 after adding a shared SessionStore or stateless mode.
   min_machines_running = 1
   processes = ["app"]
   [http_service.concurrency]


### PR DESCRIPTION
## Context

Closes #147.

The hosted app had drifted to **2 fly machines**. MCP sessions are held in-memory per instance with no shared session store and no session-sticky routing, so fly's load balancer scattered same-session requests across instances that don't share state. The first post-initialize request then failed with `-32600 "Client must send notifications/initialized before making requests"`, roughly 1 in 12 fresh connections.

## Fix

The actual fix is operational and already applied: `fly scale count 1` (destroyed the extra sjc machine). Verified against the live server with the issue's exact repro (ordered `initialize -> notifications/initialized -> tools/list`, each on a fresh connection carrying the session-id header):

```
failures: 0 / 20
```

Every session returned the full tool surface. Before the fix this repro failed ~1/12.

## This PR

Records the invariant in `fly.toml` so the drift cannot silently recur. `min_machines_running = 1` is a floor, not a cap (`fly launch` creates 2 machines by default and this key will not remove the extra one), which is exactly how the drift happened. The comment says to keep the count at 1 via `fly scale count 1` and to scale past 1 only after adding a shared `SessionStore` or stateless mode.

Lifting the single-instance constraint entirely (shared session store / stateless) remains tracked in #93.