### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-08-02
+
+### Features
+
+- Adopt final MCP protocol and structured outputs ([#153](https://github.com/joshrotenberg/cratesio-mcp/pull/153))
+
+### Miscellaneous Tasks
+
+- Harden release housekeeping ([#155](https://github.com/joshrotenberg/cratesio-mcp/pull/155))
+
+
+
 ## [0.3.1] - 2026-07-24
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "cratesio-mcp"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cratesio-mcp"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP server for querying crates.io - the Rust package registry"


### PR DESCRIPTION



## 🤖 New release

* `cratesio-mcp`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `cratesio-mcp` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function cratesio_mcp::resources::recent_searches::build, previously in file /tmp/.tmp3SMKGH/cratesio-mcp/src/resources/recent_searches.rs:9

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  AppState::save_search, previously in file /tmp/.tmp3SMKGH/cratesio-mcp/src/state.rs:136

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod cratesio_mcp::resources::recent_searches, previously in file /tmp/.tmp3SMKGH/cratesio-mcp/src/resources/recent_searches.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct cratesio_mcp::state::CrateSummary, previously in file /tmp/.tmp3SMKGH/cratesio-mcp/src/state.rs:14

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field recent_searches of struct AppState, previously in file /tmp/.tmp3SMKGH/cratesio-mcp/src/state.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0] - 2026-08-02

### Features

- Adopt final MCP protocol and structured outputs ([#153](https://github.com/joshrotenberg/cratesio-mcp/pull/153))

### Miscellaneous Tasks

- Harden release housekeeping ([#155](https://github.com/joshrotenberg/cratesio-mcp/pull/155))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).