### PR TITLE
fix: keep final subscriptions concurrent on Fly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,87 +61,25 @@ jobs:
           echo "Health check failed after $MAX_RETRIES attempts"
           exit 1
 
-      - name: Verify deployment (MCP protocol)
-        run: |
-          MAX_RETRIES=3
-          RETRY_DELAY=5
+  validate:
+    name: Validate released MCP API
+    needs: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.repository == 'joshrotenberg/cratesio-mcp'
+    env:
+      MCP_ENDPOINT: https://cratesio-mcp.fly.dev/
+      MCP_REPL_VERSION: "0.1.7"
+      EXPECTED_VERSION: ${{ github.event_name == 'push' && github.ref_name || '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
 
-          for attempt in $(seq 1 $MAX_RETRIES); do
-            echo "=== Attempt $attempt of $MAX_RETRIES ==="
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-            echo "Sending 2026-07-28 server/discover request..."
-            DISCOVER_RESPONSE=$(curl -s -X POST https://cratesio-mcp.fly.dev/ \
-              -H "Content-Type: application/json" \
-              -H "Accept: application/json" \
-              -H "MCP-Protocol-Version: 2026-07-28" \
-              -H "Mcp-Method: server/discover" \
-              -d '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"deploy-check","version":"1.0"},"io.modelcontextprotocol/clientCapabilities":{}}}}')
+      - name: Install mcp-repl
+        run: cargo install mcp-repl --version "$MCP_REPL_VERSION" --locked
 
-            echo "Discover response: $DISCOVER_RESPONSE"
-
-            if ! echo "$DISCOVER_RESPONSE" | grep -q '"supportedVersions"' || \
-               ! echo "$DISCOVER_RESPONSE" | grep -q '"2026-07-28"'; then
-              echo "2026-07-28 protocol verification failed"
-              if [ $attempt -lt $MAX_RETRIES ]; then
-                echo "Retrying in ${RETRY_DELAY}s..."
-                sleep $RETRY_DELAY
-                continue
-              fi
-              exit 1
-            fi
-
-            echo "Sending initialize request..."
-            INIT_RESPONSE=$(curl -s -D /tmp/headers.txt -X POST https://cratesio-mcp.fly.dev/ \
-              -H "Content-Type: application/json" \
-              -H "Accept: application/json" \
-              -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"deploy-check","version":"1.0"}}}')
-
-            echo "Init response: $INIT_RESPONSE"
-
-            SESSION_ID=$(grep -i "mcp-session-id" /tmp/headers.txt | cut -d' ' -f2 | tr -d '\r')
-
-            echo "Session ID: $SESSION_ID"
-
-            if [ -z "$SESSION_ID" ]; then
-              echo "Failed to get session ID"
-              if [ $attempt -lt $MAX_RETRIES ]; then
-                echo "Retrying in ${RETRY_DELAY}s..."
-                sleep $RETRY_DELAY
-                continue
-              fi
-              exit 1
-            fi
-
-            sleep 1
-
-            echo "Sending initialized notification..."
-            curl -s -X POST https://cratesio-mcp.fly.dev/ \
-              -H "Content-Type: application/json" \
-              -H "Accept: application/json" \
-              -H "MCP-Session-Id: $SESSION_ID" \
-              -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
-
-            sleep 1
-
-            echo "Sending test tool call..."
-            TOOL_RESPONSE=$(curl -s -X POST https://cratesio-mcp.fly.dev/ \
-              -H "Content-Type: application/json" \
-              -H "Accept: application/json" \
-              -H "MCP-Session-Id: $SESSION_ID" \
-              -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search_crates","arguments":{"query":"tower"}}}')
-
-            echo "Tool response: $TOOL_RESPONSE"
-
-            if echo "$TOOL_RESPONSE" | grep -q '"result"'; then
-              echo "MCP protocol verification successful!"
-              exit 0
-            else
-              echo "MCP protocol verification failed - unexpected response"
-              if [ $attempt -lt $MAX_RETRIES ]; then
-                echo "Retrying in ${RETRY_DELAY}s..."
-                sleep $RETRY_DELAY
-                continue
-              fi
-              exit 1
-            fi
-          done
+      - name: Validate released server
+        run: bash scripts/validate-release.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,7 @@ jobs:
     env:
       MCP_ENDPOINT: https://cratesio-mcp.fly.dev/
       MCP_REPL_VERSION: "0.1.7"
+      MCP_TYPESCRIPT_CLIENT_VERSION: "2.0.0"
       EXPECTED_VERSION: ${{ github.event_name == 'push' && github.ref_name || '' }}
     steps:
       - name: Checkout
@@ -80,6 +81,11 @@ jobs:
 
       - name: Install mcp-repl
         run: cargo install mcp-repl --version "$MCP_REPL_VERSION" --locked
+
+      - name: Install official TypeScript MCP client
+        run: >-
+          npm install --no-save --no-package-lock --no-audit --no-fund
+          "@modelcontextprotocol/client@$MCP_TYPESCRIPT_CLIENT_VERSION"
 
       - name: Validate released server
         run: bash scripts/validate-release.sh

--- a/fly.toml
+++ b/fly.toml
@@ -27,7 +27,10 @@ primary_region = "sjc"
   min_machines_running = 1
   processes = ["app"]
   [http_service.concurrency]
-    type = "requests"
+    # Final-protocol subscriptions/listen responses remain open indefinitely.
+    # Use one backend connection per HTTP request so Fly Proxy cannot pool a
+    # follow-up request behind the long-lived SSE response (#157).
+    type = "connections"
     hard_limit = 35
     soft_limit = 25
 

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -5,6 +5,7 @@ endpoint="${MCP_ENDPOINT:-https://cratesio-mcp.fly.dev/}"
 repl="${MCP_REPL_BIN:-mcp-repl}"
 max_attempts="${MCP_VALIDATION_ATTEMPTS:-3}"
 retry_delay="${MCP_VALIDATION_RETRY_DELAY_SECS:-5}"
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 
 validate_tools() {
   local protocol="$1"
@@ -73,11 +74,19 @@ validate_tool_result() {
   }' <<<"$result_json"
 }
 
+validate_subscription_concurrency() {
+  if ! node "$script_dir/validate-subscription.mjs" "$endpoint"; then
+    echo "official client could not list tools with subscriptions/listen open" >&2
+    return 1
+  fi
+}
+
 for attempt in $(seq 1 "$max_attempts"); do
   echo "MCP release validation attempt $attempt/$max_attempts"
 
   if validate_tools stable \
     && validate_tools 2026-07-28 \
+    && validate_subscription_concurrency \
     && validate_tool_result; then
     echo "MCP release validation passed"
     exit 0

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+endpoint="${MCP_ENDPOINT:-https://cratesio-mcp.fly.dev/}"
+repl="${MCP_REPL_BIN:-mcp-repl}"
+max_attempts="${MCP_VALIDATION_ATTEMPTS:-3}"
+retry_delay="${MCP_VALIDATION_RETRY_DELAY_SECS:-5}"
+
+validate_tools() {
+  local protocol="$1"
+  local tools_json
+
+  if ! tools_json=$("$repl" --protocol "$protocol" --http "$endpoint" --json -e tools); then
+    echo "mcp-repl failed using the $protocol lifecycle" >&2
+    return 1
+  fi
+
+  if ! jq -e '
+    any(.[];
+      .name == "search_crates"
+      and .outputSchema.type == "object"
+      and (.outputSchema.required | index("crates") != null)
+      and (.outputSchema.required | index("meta") != null)
+      and .annotations.readOnlyHint == true
+      and .annotations.idempotentHint == true
+    )
+  ' >/dev/null <<<"$tools_json"; then
+    echo "search_crates is missing its expected schema or annotations ($protocol)" >&2
+    jq . <<<"$tools_json" >&2
+    return 1
+  fi
+}
+
+validate_tool_result() {
+  local result_json
+
+  if ! result_json=$(
+    "$repl" --protocol 2026-07-28 --http "$endpoint" --json \
+      -e "search_crates query=tower-mcp"
+  ); then
+    echo "search_crates failed using the final lifecycle" >&2
+    return 1
+  fi
+
+  if ! jq -e '
+    (.isError // false) == false
+    and (.structuredContent.crates | type) == "array"
+    and (.structuredContent.crates | length) > 0
+    and any(.structuredContent.crates[]; .name == "tower-mcp")
+    and .structuredContent.meta.total > 0
+    and any(.content[]; .type == "text" and (.text | contains("tower-mcp")))
+  ' >/dev/null <<<"$result_json"; then
+    echo "search_crates returned an unexpected tool result" >&2
+    jq . <<<"$result_json" >&2
+    return 1
+  fi
+
+  if [[ -n "${EXPECTED_VERSION:-}" ]]; then
+    local expected_version="${EXPECTED_VERSION#v}"
+    if ! jq -e --arg expected "$expected_version" '
+      ._meta["io.modelcontextprotocol/serverInfo"].version == $expected
+    ' >/dev/null <<<"$result_json"; then
+      echo "live server version does not match release $EXPECTED_VERSION" >&2
+      jq '._meta' <<<"$result_json" >&2
+      return 1
+    fi
+  fi
+
+  jq '{
+    server: ._meta["io.modelcontextprotocol/serverInfo"],
+    matchedCrates: [.structuredContent.crates[].name],
+    total: .structuredContent.meta.total
+  }' <<<"$result_json"
+}
+
+for attempt in $(seq 1 "$max_attempts"); do
+  echo "MCP release validation attempt $attempt/$max_attempts"
+
+  if validate_tools stable \
+    && validate_tools 2026-07-28 \
+    && validate_tool_result; then
+    echo "MCP release validation passed"
+    exit 0
+  fi
+
+  if [[ "$attempt" -lt "$max_attempts" ]]; then
+    echo "Retrying in ${retry_delay}s..." >&2
+    sleep "$retry_delay"
+  fi
+done
+
+echo "MCP release validation failed after $max_attempts attempts" >&2
+exit 1

--- a/scripts/validate-subscription.mjs
+++ b/scripts/validate-subscription.mjs
@@ -1,0 +1,59 @@
+const endpoint = process.argv[2] ?? process.env.MCP_ENDPOINT;
+if (!endpoint) {
+  throw new Error('usage: node validate-subscription.mjs <MCP endpoint>');
+}
+
+const timeoutMs = Number(process.env.MCP_SUBSCRIPTION_TIMEOUT_MS ?? '10000');
+if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+  throw new Error('MCP_SUBSCRIPTION_TIMEOUT_MS must be a positive number');
+}
+
+const moduleSpecifier =
+  process.env.MCP_CLIENT_MODULE ?? '@modelcontextprotocol/client';
+const { Client, StreamableHTTPClientTransport } = await import(moduleSpecifier);
+
+const client = new Client(
+  { name: 'cratesio-mcp-release-validation', version: '1.0.0' },
+  {
+    versionNegotiation: { mode: 'auto' },
+    listChanged: {
+      tools: { onChanged() {} },
+    },
+  },
+);
+
+// Closing an active subscription aborts its fetch. That is expected cleanup,
+// not a validation failure, so only surfaced request failures are thrown.
+client.onerror = () => {};
+
+let timeout;
+try {
+  await client.connect(
+    new StreamableHTTPClientTransport(new URL(endpoint)),
+  );
+
+  if (client.getProtocolEra() !== 'modern') {
+    throw new Error('server did not negotiate the final MCP protocol');
+  }
+
+  const tools = await Promise.race([
+    client.listTools(),
+    new Promise((_, reject) => {
+      timeout = setTimeout(
+        () => reject(new Error(`tools/list timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+    }),
+  ]);
+
+  if (!tools.tools.some((tool) => tool.name === 'search_crates')) {
+    throw new Error('tools/list did not include search_crates');
+  }
+
+  console.log(
+    `Subscription concurrency validation passed (${tools.tools.length} tools)`,
+  );
+} finally {
+  clearTimeout(timeout);
+  await client.close();
+}


### PR DESCRIPTION
## Summary

- switch Fly concurrency accounting from pooled HTTP requests to backend connections
- keep the existing mcp-repl release checks for both stable and final protocol behavior
- validate final `subscriptions/listen` concurrency with the official TypeScript client 2.0.0 after every deploy

## Why

A final-protocol client can open `subscriptions/listen` against the Fly deployment, but its following `tools/list` request then times out. The same official-client probe succeeds locally, isolating the failure to the deployed proxy path.

Fly documents that request-based concurrency may pool backend connections. Using connection-based concurrency gives each HTTP request its own backend connection so a long-lived SSE response cannot hold the pooled path needed by follow-up requests.

The mcp-repl one-shot checks do not open a final subscription, so the deployment gate uses the official client configuration that reproduces #157.

## Validation

- `cargo test --all-features`
- `shellcheck scripts/validate-release.sh`
- `actionlint .github/workflows/deploy.yml`
- `node --check scripts/validate-subscription.mjs`
- `flyctl config validate --config fly.toml`
- official-client probe passes locally with all 29 tools
- the same probe times out against the current Fly deployment, confirming the regression gate is sensitive before deployment

## Deployment

This PR remains draft. The Fly setting changes only after a repo-driven deploy; the post-deploy validation job will then verify the workaround against the live endpoint.

Addresses #157.