### PR TITLE
fix: clear Fly Proxy connection saturation and probe the deployment

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,107 @@
+name: Uptime
+
+# Probes the deployed server from outside Fly, on a schedule.
+#
+# The Fly-managed health check in fly.toml runs on the machine's private
+# network and bypasses Fly Proxy's concurrency accounting, so it cannot see a
+# proxy-level outage: during #158 it reported "passing" for hours while every
+# public request got PR01 "no known healthy instances". Only a probe that goes
+# through the public hostname observes what clients actually get.
+#
+# Cadence is the detection latency for that class of outage. Public-repo
+# Actions minutes are free, so this runs every 2 hours rather than daily.
+on:
+  schedule:
+    - cron: "0 */2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: uptime
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  probe:
+    name: Probe deployed MCP server
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.repository == 'joshrotenberg/cratesio-mcp'
+    env:
+      MCP_ENDPOINT: https://cratesio-mcp.fly.dev/
+      MCP_REPL_VERSION: "0.1.7"
+      MCP_TYPESCRIPT_CLIENT_VERSION: "2.0.0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Fast, dependency-free reachability check. Runs before the toolchain
+      # setup so a proxy-level outage fails in seconds with an obvious message
+      # instead of waiting on a cargo install that is irrelevant to the fault.
+      - name: Probe public health endpoint
+        run: |
+          status=$(curl -s -o /dev/null -m 15 -w '%{http_code}' \
+            "${MCP_ENDPOINT%/}/health" || echo "000")
+          echo "GET /health -> $status"
+          if [ "$status" != "200" ]; then
+            echo "::error::Public health endpoint returned $status (000 = timeout/refused)."
+            exit 1
+          fi
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install mcp-repl
+        run: cargo install mcp-repl --version "$MCP_REPL_VERSION" --locked
+
+      - name: Install official TypeScript MCP client
+        run: >-
+          npm install --no-save --no-package-lock --no-audit --no-fund
+          "@modelcontextprotocol/client@$MCP_TYPESCRIPT_CLIENT_VERSION"
+
+      # EXPECTED_VERSION is deliberately unset: this checks that the deployed
+      # server works, not that it matches any particular release tag.
+      - name: Validate deployed server
+        run: bash scripts/validate-release.sh
+
+      # One open issue per outage, not one per failed run.
+      - name: Open or update outage issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          existing=$(gh issue list --label uptime --state open \
+            --json number -q '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Uptime probe failed again: $RUN_URL"
+            exit 0
+          fi
+          gh label create uptime --description "Automated uptime probe" \
+            --color B60205 2>/dev/null || true
+          gh issue create --label uptime \
+            --title "Deployed server failing uptime probe" \
+            --body "The scheduled uptime probe against \`$MCP_ENDPOINT\` failed.
+
+Run: $RUN_URL
+
+Check proxy-level reachability first. The Fly health check cannot detect
+connection-limit saturation (see #158), so \`fly status\` reporting a passing
+check does not rule it out:
+
+\`\`\`
+fly ssh console -a cratesio-mcp -C \"sh -c 'cat /proc/net/tcp'\" | awk 'NR>2 && \$4==\"01\" {n++} END {print n}'
+\`\`\`
+
+Compare that count against \`hard_limit\` in \`fly.toml\`."
+
+      - name: Close outage issue on recovery
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for n in $(gh issue list --label uptime --state open --json number -q '.[].number'); do
+            gh issue close "$n" --comment "Uptime probe passing again."
+          done

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -42,8 +42,10 @@ jobs:
       # instead of waiting on a cargo install that is irrelevant to the fault.
       - name: Probe public health endpoint
         run: |
+          # curl already writes 000 for a timeout or refused connection, so
+          # this only needs to survive the non-zero exit, not substitute a code.
           status=$(curl -s -o /dev/null -m 15 -w '%{http_code}' \
-            "${MCP_ENDPOINT%/}/health" || echo "000")
+            "${MCP_ENDPOINT%/}/health" || true)
           echo "GET /health -> $status"
           if [ "$status" != "200" ]; then
             echo "::error::Public health endpoint returned $status (000 = timeout/refused)."
@@ -81,21 +83,25 @@ jobs:
           fi
           gh label create uptime --description "Automated uptime probe" \
             --color B60205 2>/dev/null || true
+          cat >/tmp/body.md <<EOF
+          The scheduled uptime probe against \`$MCP_ENDPOINT\` failed.
+
+          Run: $RUN_URL
+
+          Check proxy-level reachability first. The Fly health check cannot
+          detect connection-limit saturation (see #158), so \`fly status\`
+          reporting a passing check does not rule it out:
+
+          \`\`\`
+          fly ssh console -a cratesio-mcp -C "sh -c 'cat /proc/net/tcp'" \\
+            | awk 'NR>2 && \$4=="01" {n++} END {print n}'
+          \`\`\`
+
+          Compare that count against \`hard_limit\` in \`fly.toml\`.
+          EOF
           gh issue create --label uptime \
             --title "Deployed server failing uptime probe" \
-            --body "The scheduled uptime probe against \`$MCP_ENDPOINT\` failed.
-
-Run: $RUN_URL
-
-Check proxy-level reachability first. The Fly health check cannot detect
-connection-limit saturation (see #158), so \`fly status\` reporting a passing
-check does not rule it out:
-
-\`\`\`
-fly ssh console -a cratesio-mcp -C \"sh -c 'cat /proc/net/tcp'\" | awk 'NR>2 && \$4==\"01\" {n++} END {print n}'
-\`\`\`
-
-Compare that count against \`hard_limit\` in \`fly.toml\`."
+            --body-file /tmp/body.md
 
       - name: Close outage issue on recovery
         if: success()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,6 +1956,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2337,9 +2338,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-mcp"
-version = "0.17.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0747f1ae227377580fd5cd840c2eb00b8e4cdc6918aea154d82c83c8edd6d61"
+checksum = "f8ef1781ae19c64b9a7dc9202a35ed63ee45a2e97ccc5b97747fd197d0bf6f80"
 dependencies = [
  "async-trait",
  "axum",
@@ -2368,11 +2369,12 @@ dependencies = [
 
 [[package]]
 name = "tower-mcp-types"
-version = "0.17.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903efccc0f41dfdfd96ee2967d0c080b8c1413190dc322fc3abbcf284abc427a"
+checksum = "31aace137391a8ced9420b20337795f73e55e91992b510781d4056d560f032dd"
 dependencies = [
  "base64 0.23.0",
+ "indexmap",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ mcp = [
 
 [dependencies]
 # Core MCP (server only)
-tower-mcp = { version = "0.17.1", features = ["http", "protocol-2026-07-28", "testing"], optional = true }
+tower-mcp = { version = "0.20.0", features = ["http", "protocol-2026-07-28", "testing"], optional = true }
 # HTTP server types, for the client-IP request-logging middleware on the HTTP transport
 axum = { version = "0.8", optional = true }
 

--- a/fly.toml
+++ b/fly.toml
@@ -30,9 +30,19 @@ primary_region = "sjc"
     # Final-protocol subscriptions/listen responses remain open indefinitely.
     # Use one backend connection per HTTP request so Fly Proxy cannot pool a
     # follow-up request behind the long-lived SSE response (#157).
+    #
+    # These limits count OPEN CONNECTIONS, not in-flight requests, so idle
+    # keep-alive connections the proxy pools count against them. Real traffic
+    # holds ~35 pooled connections at steady state, so the previous 35/25 was
+    # at capacity permanently: the proxy had no routable candidate and served
+    # PR01 "no known healthy instances" for every request while the machine sat
+    # at load 0.00 (#158). The flyd health check runs on the private network and
+    # bypasses proxy concurrency accounting, so it kept reporting "passing"
+    # throughout. Idle connections cost a few KB each, so headroom is cheap;
+    # keep these an order of magnitude above observed steady-state concurrency.
     type = "connections"
-    hard_limit = 35
-    soft_limit = 25
+    hard_limit = 400
+    soft_limit = 300
 
   # Fly-managed HTTP health check on /health. A failing check makes a deploy
   # fail (instead of "succeeding" while the app serves nothing -- the gap that


### PR DESCRIPTION
Closes #158.

## Context

The deployed server was unreachable from the public hostname: 503 or timeout
on every request, while `fly status` reported the machine `started` with a
passing check. The machine was pinned at exactly `hard_limit = 35` established
connections from Fly Proxy, all idle, at load average `0.00`.

`type = "connections"` (added in #156 to fix #157) counts open connections
rather than in-flight requests, so idle keep-alive connections the proxy pools
count against the limit. With the limit at 35 and the steady-state pool also at
35, the instance sat permanently at capacity and the proxy stopped routing.

Full evidence in #158.

## Changes

### `fix(fly)`: raise connection limits to 400/300

Restores headroom above the roughly 35 pooled connections real traffic holds.
Idle connections cost a few KB each. This keeps #156's fix for #157 intact
rather than reverting to `type = "requests"`.

Already deployed out of band to end the outage. This commit brings the repo in
line with the live config.

### `chore(deps)`: upgrade tower-mcp 0.17.1 to 0.20.0

Picks up subscriptions/listen stream handling from 0.18.2 (tower-mcp#1185,
tower-mcp#1186), in-process server-initiated requests from 0.19.0, and
caller-drop cancellation from 0.20.0. No source changes required.

Not yet deployed: deploys fire on release tags, and this config change went out
on the existing v0.4.0 image.

### `ci`: probe the deployed server on a schedule

The Fly check originates on the machine's private network and bypasses proxy
concurrency accounting, so it cannot detect this failure mode. A probe through
the public hostname can.

Runs every 2 hours. A dependency-free curl of `/health` fails in seconds on a
proxy-level fault, then `scripts/validate-release.sh` exercises the real MCP
lifecycle against production. Failures open a single labelled issue per outage
and close it on recovery.

## Measurements after the fix

Sampled the machine's socket table every 45s for 20 minutes following the
deploy. The count sat at exactly 35 on every sample, with `/health` returning
200 throughout. It reached 35 within about 3 minutes of restart and did not
move after that, so the pool is not growing toward the new limit.

One caveat on how far that goes. A 25-connection burst against `/health` did
not raise the count either, but that does not prove 35 is an intrinsic cap:
`/health` returns in ~40ms, so the burst was absorbed by reuse of the existing
warm connections rather than forcing new ones. Proving a hard ceiling would
need more than 35 simultaneous slow requests, which is not worth running
against production.

So: the pool is stable at 35 with more than 10x headroom, and if it does drift
upward over days the scheduled probe now catches it within 2 hours instead of
never.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (40 tests plus doctests)
- [x] Service restored: `/health` 200 in ~40ms, `initialize` returns 29 tools
- [x] Connection count stable at 35 over 20 minutes under the raised limit
- [x] Workflow YAML parses, and both run blocks executed locally against
      production and a dead endpoint with `gh` stubbed

The workflow cannot be exercised via `workflow_dispatch` until it is on the
default branch, hence the local execution of its steps instead.