### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] - 2026-08-05
+
+### Bug Fixes
+
+- Clear Fly Proxy connection saturation and probe the deployment ([#159](https://github.com/joshrotenberg/cratesio-mcp/pull/159))
+
+
+
 ## [0.4.0] - 2026-08-02
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Clear Fly Proxy connection saturation and probe the deployment ([#159](https://github.com/joshrotenberg/cratesio-mcp/pull/159))
 
+### Miscellaneous Tasks
+
+- Upgrade tower-mcp 0.17.1 -> 0.20.0 ([#159](https://github.com/joshrotenberg/cratesio-mcp/pull/159))
+
 
 
 ## [0.4.0] - 2026-08-02

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "cratesio-mcp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cratesio-mcp"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.90"
 description = "MCP server for querying crates.io - the Rust package registry"


### PR DESCRIPTION



## 🤖 New release

* `cratesio-mcp`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1] - 2026-08-05

### Bug Fixes

- Clear Fly Proxy connection saturation and probe the deployment ([#159](https://github.com/joshrotenberg/cratesio-mcp/pull/159))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).